### PR TITLE
Enable guest LLOs

### DIFF
--- a/pallet-lo-authority-list/src/lib.rs
+++ b/pallet-lo-authority-list/src/lib.rs
@@ -24,15 +24,22 @@ use frame_system::RawOrigin;
 
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Encode, Decode, Clone, PartialEq, Eq, Debug, TypeInfo)]
-pub struct LegalOfficerData {
+pub enum LegalOfficerData<AccountId> {
+	Host(HostData),
+	Guest(AccountId),
+}
+
+#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Encode, Decode, Clone, PartialEq, Eq, Debug, TypeInfo)]
+pub struct HostData {
 	pub node_id: Option<PeerId>,
 	pub base_url: Option<Vec<u8>>,
 }
 
-impl Default for LegalOfficerData {
+impl Default for HostData {
 
 	fn default() -> Self {
-		LegalOfficerData {
+		HostData {
 			node_id: Option::None,
 			base_url: Option::None,
 		}
@@ -72,7 +79,7 @@ pub mod pallet {
 	/// All LOs indexed by their account ID.
 	#[pallet::storage]
 	#[pallet::getter(fn legal_officer_set)]
-	pub type LegalOfficerSet<T> = StorageMap<_, Blake2_128Concat, <T as frame_system::Config>::AccountId, LegalOfficerData>;
+	pub type LegalOfficerSet<T> = StorageMap<_, Blake2_128Concat, <T as frame_system::Config>::AccountId, LegalOfficerData<<T as frame_system::Config>::AccountId>>;
 
 	/// The set of LO nodes.
 	#[pallet::storage]
@@ -83,11 +90,12 @@ pub mod pallet {
 	pub enum StorageVersion {
 		V1,
 		V2AddOnchainSettings,
+		V3GuestLegalOfficers,
 	}
 
 	impl Default for StorageVersion {
 		fn default() -> StorageVersion {
-			return StorageVersion::V1;
+			return StorageVersion::V3GuestLegalOfficers;
 		}
 	}
 
@@ -98,7 +106,7 @@ pub mod pallet {
 
 	#[pallet::genesis_config]
 	pub struct GenesisConfig<T: Config> {
-		pub legal_officers: Vec<(T::AccountId, LegalOfficerData)>,
+		pub legal_officers: Vec<(T::AccountId, LegalOfficerData<T::AccountId>)>,
 	}
 
 	#[cfg(feature = "std")]
@@ -134,6 +142,16 @@ pub mod pallet {
 		NotFound,
 		/// The Peer ID is already assigned to another LO.
 		PeerIdAlreadyInUse,
+		/// The host has at least one guest and cannot become a guest or be removed
+		HostHasGuest,
+		/// Trying to add a guest with another guest as host
+		GuestOfGuest,
+		/// Trying to add a guest with unknown host
+		HostNotFound,
+		/// Host cannot convert itself into a guest
+		HostCannotConvert,
+		/// Guest cannot update
+		GuestCannotUpdate,
 	}
 
 	#[pallet::hooks]
@@ -147,14 +165,15 @@ pub mod pallet {
 		pub fn add_legal_officer(
 			origin: OriginFor<T>,
 			legal_officer_id: T::AccountId,
-			data: LegalOfficerData,
+			data: LegalOfficerData<T::AccountId>,
 		) -> DispatchResultWithPostInfo {
 			T::AddOrigin::ensure_origin(origin)?;
 			if <LegalOfficerSet<T>>::contains_key(&legal_officer_id) {
 				Err(Error::<T>::AlreadyExists)?
 			} else {
-				<LegalOfficerSet<T>>::insert(legal_officer_id.clone(), data);
-				Self::reset_legal_officer_nodes()?;
+				Self::ensure_host_if_guest(&data)?;
+				<LegalOfficerSet<T>>::insert(legal_officer_id.clone(), &data);
+				Self::try_reset_legal_officer_nodes(&data)?;
 
 				Self::deposit_event(Event::LoAdded(legal_officer_id));
 				Ok(().into())
@@ -168,11 +187,14 @@ pub mod pallet {
 			legal_officer_id: T::AccountId,
 		) -> DispatchResultWithPostInfo {
 			T::RemoveOrigin::ensure_origin(origin)?;
-			if ! <LegalOfficerSet<T>>::contains_key(&legal_officer_id) {
+			let to_remove = <LegalOfficerSet<T>>::get(&legal_officer_id);
+			if to_remove.is_none() {
 				Err(Error::<T>::NotFound)?
+			} else if Self::host_has_guest(&legal_officer_id) {
+				Err(Error::<T>::HostHasGuest)?
 			} else {
 				<LegalOfficerSet<T>>::remove(&legal_officer_id);
-				Self::reset_legal_officer_nodes()?;
+				Self::try_reset_legal_officer_nodes(&to_remove.unwrap())?;
 
 				Self::deposit_event(Event::LoRemoved(legal_officer_id));
 				Ok(().into())
@@ -184,17 +206,45 @@ pub mod pallet {
 		pub fn update_legal_officer(
 			origin: OriginFor<T>,
 			legal_officer_id: T::AccountId,
-			data: LegalOfficerData,
+			data: LegalOfficerData<T::AccountId>,
 		) -> DispatchResultWithPostInfo {
 			let who = ensure_signed_or_root(origin.clone())?;
-			if who.is_some() && who.unwrap() != legal_officer_id {
+			if who.is_some() && who.clone().unwrap() != legal_officer_id {
 				T::UpdateOrigin::ensure_origin(origin)?;
 			}
-			if ! <LegalOfficerSet<T>>::contains_key(&legal_officer_id) {
+			let to_update = <LegalOfficerSet<T>>::get(&legal_officer_id);
+			if to_update.is_none() {
 				Err(Error::<T>::NotFound)?
 			} else {
-				<LegalOfficerSet<T>>::set(legal_officer_id.clone(), Some(data));
-				Self::reset_legal_officer_nodes()?;
+				Self::ensure_host_if_guest(&data)?;
+				let some_to_update = to_update.unwrap();
+				match some_to_update {
+					LegalOfficerData::Host(_) => match data {
+						LegalOfficerData::Guest(_) => {
+							if Self::host_has_guest(&legal_officer_id) {
+								Err(Error::<T>::HostHasGuest)?
+							}
+							if who.is_some() && who.unwrap() == legal_officer_id {
+								Err(Error::<T>::HostCannotConvert)?
+							}
+						},
+						_ => (),
+					},
+					LegalOfficerData::Guest(_) => if who.is_some() && who.unwrap() == legal_officer_id {
+						Err(Error::<T>::GuestCannotUpdate)?
+					},
+				}
+
+				<LegalOfficerSet<T>>::set(legal_officer_id.clone(), Some(data.clone()));
+				match some_to_update {
+					LegalOfficerData::Guest(_) => match data {
+						LegalOfficerData::Host(_) => Self::reset_legal_officer_nodes()?,
+						LegalOfficerData::Guest(_) => (),
+					},
+					LegalOfficerData::Host(_) => {
+						Self::reset_legal_officer_nodes()?
+					},
+				}
 
 				Self::deposit_event(Event::LoUpdated(legal_officer_id));
 				Ok(().into())
@@ -206,18 +256,30 @@ pub mod pallet {
 pub type OuterOrigin<T> = <T as frame_system::Config>::RuntimeOrigin;
 
 impl<T: Config> Pallet<T> {
-	fn initialize_legal_officers(legal_officers: &Vec<(T::AccountId, LegalOfficerData)>) {
+	fn initialize_legal_officers(legal_officers: &Vec<(T::AccountId, LegalOfficerData<T::AccountId>)>) {
 		for legal_officer in legal_officers {
-			LegalOfficerSet::<T>::insert::<&T::AccountId, &LegalOfficerData>(&(legal_officer.0), &(legal_officer.1));
+			LegalOfficerSet::<T>::insert::<&T::AccountId, &LegalOfficerData<T::AccountId>>(&(legal_officer.0), &(legal_officer.1));
 			LegalOfficerNodes::<T>::set(BTreeSet::new());
+		}
+	}
+
+	fn try_reset_legal_officer_nodes(added_or_removed_data: &LegalOfficerData<T::AccountId>) -> Result<(), Error<T>> {
+		match added_or_removed_data {
+			LegalOfficerData::Host(_) => Self::reset_legal_officer_nodes(),
+			_ => Ok(()),
 		}
 	}
 
 	fn reset_legal_officer_nodes() -> Result<(), Error<T>> {
 		let mut new_nodes = BTreeSet::new();
 		for data in LegalOfficerSet::<T>::iter_values() {
-			if data.node_id.is_some() && ! new_nodes.insert(data.node_id.unwrap()) {
-				Err(Error::<T>::PeerIdAlreadyInUse)?
+			match data {
+				LegalOfficerData::Host(host_data) => {
+					if host_data.node_id.is_some() && ! new_nodes.insert(host_data.node_id.unwrap()) {
+						Err(Error::<T>::PeerIdAlreadyInUse)?
+					}
+				},
+				_ => (),
 			}
 		}
 		LegalOfficerNodes::<T>::set(new_nodes);
@@ -226,6 +288,36 @@ impl<T: Config> Pallet<T> {
 
 	pub fn ensure_legal_officer(o: T::RuntimeOrigin) -> Result<T::AccountId, BadOrigin> {
 		<Self as EnsureOrigin<T::RuntimeOrigin>>::ensure_origin(o)
+	}
+
+	fn host_has_guest(host_id: &T::AccountId) -> bool {
+		for data in LegalOfficerSet::<T>::iter_values() {
+			match data {
+				LegalOfficerData::Guest(host) =>
+					if host == *host_id { return true },
+				_ => (),
+			}
+		}
+		false
+	}
+
+	fn ensure_host_if_guest(data: &LegalOfficerData<T::AccountId>) -> Result<(), Error<T>> {
+		match &data {
+			LegalOfficerData::Guest(host) => Self::ensure_host(host),
+			_ => Ok(()),
+		}
+	}
+
+	fn ensure_host(id: &T::AccountId) -> Result<(), Error<T>> {
+		let potential_host = LegalOfficerSet::<T>::get(id);
+		if potential_host.is_none() {
+			Err(Error::<T>::HostNotFound)
+		} else {
+			match potential_host.unwrap() {
+				LegalOfficerData::Guest(_) => Err(Error::<T>::GuestOfGuest),
+				LegalOfficerData::Host(_) => Ok(()),
+			}
+		}
 	}
 }
 

--- a/pallet-lo-authority-list/src/migrations.rs
+++ b/pallet-lo-authority-list/src/migrations.rs
@@ -1,25 +1,23 @@
 use frame_support::traits::Get;
 use frame_support::weights::Weight;
 use frame_support::traits::OnRuntimeUpgrade;
-use sp_std::collections::btree_set::BTreeSet;
 
 use crate::{Config, PalletStorageVersion, pallet::StorageVersion};
 
-pub mod v2 {
+pub mod v3 {
 	use super::*;
-	use crate::{LegalOfficerSet, LegalOfficerNodes};
+	use crate::{LegalOfficerSet, LegalOfficerData, HostData};
 
-	pub struct AddOnchainSettings<T>(sp_std::marker::PhantomData<T>);
-	impl<T: Config> OnRuntimeUpgrade for AddOnchainSettings<T> {
+	pub struct ConvertIntoHostData<T>(sp_std::marker::PhantomData<T>);
+	impl<T: Config> OnRuntimeUpgrade for ConvertIntoHostData<T> {
 
 		fn on_runtime_upgrade() -> Weight {
 			super::do_storage_upgrade::<T, _>(
-				StorageVersion::V1,
 				StorageVersion::V2AddOnchainSettings,
-				"AddOnchainSettings",
+				StorageVersion::V3GuestLegalOfficers,
+				"ConvertIntoHostData",
 				|| {
-					LegalOfficerSet::<T>::translate(|_, _: bool| Some(Default::default()));
-					LegalOfficerNodes::<T>::set(BTreeSet::new());
+					LegalOfficerSet::<T>::translate_values(|host_data: HostData| Some(LegalOfficerData::Host(host_data)))
 				}
 			)
 		}

--- a/pallet-lo-authority-list/src/tests.rs
+++ b/pallet-lo-authority-list/src/tests.rs
@@ -1,4 +1,4 @@
-use crate::{mock::*, LegalOfficerData, Error};
+use crate::{mock::*, LegalOfficerData, Error, HostData};
 use frame_support::{assert_err, assert_ok, error::BadOrigin};
 use logion_shared::IsLegalOfficer;
 use sp_core::OpaquePeerId;
@@ -6,9 +6,27 @@ use sp_core::OpaquePeerId;
 const LEGAL_OFFICER_ID: u64 = 1;
 const ANOTHER_ID: u64 = 2;
 const LEGAL_OFFICER_ID2: u64 = 3;
+const LEGAL_OFFICER_ID3: u64 = 4;
+
+impl Default for LegalOfficerData<<Test as frame_system::Config>::AccountId> {
+	fn default() -> Self {
+		LegalOfficerData::Host(Default::default())
+	}
+}
+
+impl TryFrom<LegalOfficerData<<Test as frame_system::Config>::AccountId>> for HostData {
+	type Error = ();
+
+	fn try_from(value: LegalOfficerData<<Test as frame_system::Config>::AccountId>) -> Result<Self, Self::Error> {
+		match value {
+			LegalOfficerData::Host(data) => Ok(data),
+			_ => Err(())
+		}		
+	}
+}
 
 #[test]
-fn it_adds_lo() {
+fn it_adds_host() {
 	new_test_ext().execute_with(|| {
 		assert_ok!(LoAuthorityList::add_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID, Default::default()));
 		assert!(LoAuthorityList::legal_officer_set(LEGAL_OFFICER_ID).is_some());
@@ -17,7 +35,7 @@ fn it_adds_lo() {
 }
 
 #[test]
-fn it_removes_lo() {
+fn it_removes_host() {
 	new_test_ext().execute_with(|| {
 		assert_ok!(LoAuthorityList::add_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID, Default::default()));
 		assert_ok!(LoAuthorityList::remove_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID));
@@ -27,14 +45,14 @@ fn it_removes_lo() {
 }
 
 #[test]
-fn it_fails_adding_if_not_manager() {
+fn it_fails_adding_if_not_superuser() {
 	new_test_ext().execute_with(|| {
 		assert_err!(LoAuthorityList::add_legal_officer(RuntimeOrigin::signed(0), LEGAL_OFFICER_ID, Default::default()), BadOrigin);
 	});
 }
 
 #[test]
-fn it_fails_removing_if_not_manager() {
+fn it_fails_removing_if_not_superuser() {
 	new_test_ext().execute_with(|| {
 		assert_err!(LoAuthorityList::remove_legal_officer(RuntimeOrigin::signed(0), LEGAL_OFFICER_ID), BadOrigin);
 	});
@@ -74,34 +92,36 @@ fn it_detects_regular_user() {
 }
 
 #[test]
-fn it_lets_lo_update() {
+fn it_lets_host_update() {
 	new_test_ext().execute_with(|| {
 		assert_ok!(LoAuthorityList::add_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID, Default::default()));
 		let base_url = "https://node.logion.network".as_bytes().to_vec();
 		let node_id = OpaquePeerId(bs58::decode("12D3KooWBmAwcd4PJNJvfV89HwE48nwkRmAgo8Vy3uQEyNNHBox2").into_vec().unwrap());
-		assert_ok!(LoAuthorityList::update_legal_officer(RuntimeOrigin::signed(LEGAL_OFFICER_ID), LEGAL_OFFICER_ID, LegalOfficerData {
+		assert_ok!(LoAuthorityList::update_legal_officer(RuntimeOrigin::signed(LEGAL_OFFICER_ID), LEGAL_OFFICER_ID, LegalOfficerData::Host(HostData {
 			node_id: Option::Some(node_id.clone()),
 			base_url: Option::Some(base_url.clone()),
-		}));
-		assert_eq!(LoAuthorityList::legal_officer_set(LEGAL_OFFICER_ID).unwrap().base_url.unwrap(), base_url);
-		assert_eq!(LoAuthorityList::legal_officer_set(LEGAL_OFFICER_ID).unwrap().node_id.unwrap(), node_id);
+		})));
+		let data: HostData = LoAuthorityList::legal_officer_set(LEGAL_OFFICER_ID).unwrap().try_into().unwrap();
+		assert_eq!(data.base_url.unwrap(), base_url);
+		assert_eq!(data.node_id.unwrap(), node_id);
 		assert_eq!(LoAuthorityList::legal_officer_nodes().len(), 1);
 		assert!(LoAuthorityList::legal_officer_nodes().contains(&node_id));
 	});
 }
 
 #[test]
-fn it_lets_manager_update() {
+fn it_lets_superuser_update() {
 	new_test_ext().execute_with(|| {
 		assert_ok!(LoAuthorityList::add_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID, Default::default()));
 		let base_url = "https://node.logion.network".as_bytes().to_vec();
 		let node_id = OpaquePeerId(bs58::decode("12D3KooWBmAwcd4PJNJvfV89HwE48nwkRmAgo8Vy3uQEyNNHBox2").into_vec().unwrap());
-		assert_ok!(LoAuthorityList::update_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID, LegalOfficerData {
+		assert_ok!(LoAuthorityList::update_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID, LegalOfficerData::Host(HostData {
 			node_id: Option::Some(node_id.clone()),
 			base_url: Option::Some(base_url.clone()),
-		}));
-		assert_eq!(LoAuthorityList::legal_officer_set(LEGAL_OFFICER_ID).unwrap().base_url.unwrap(), base_url);
-		assert_eq!(LoAuthorityList::legal_officer_set(LEGAL_OFFICER_ID).unwrap().node_id.unwrap(), node_id);
+		})));
+		let data: HostData = LoAuthorityList::legal_officer_set(LEGAL_OFFICER_ID).unwrap().try_into().unwrap();
+		assert_eq!(data.base_url.unwrap(), base_url);
+		assert_eq!(data.node_id.unwrap(), node_id);
 		assert_eq!(LoAuthorityList::legal_officer_nodes().len(), 1);
 		assert!(LoAuthorityList::legal_officer_nodes().contains(&node_id));
 	});
@@ -112,16 +132,16 @@ fn it_fails_add_if_peer_id_already_in_use() {
 	new_test_ext().execute_with(|| {
 		let base_url1 = "https://node1.logion.network".as_bytes().to_vec();
 		let node_id1 = OpaquePeerId(bs58::decode("12D3KooWBmAwcd4PJNJvfV89HwE48nwkRmAgo8Vy3uQEyNNHBox2").into_vec().unwrap());
-		assert_ok!(LoAuthorityList::add_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID, LegalOfficerData {
+		assert_ok!(LoAuthorityList::add_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID, LegalOfficerData::Host(HostData {
 			node_id: Option::Some(node_id1.clone()),
 			base_url: Option::Some(base_url1.clone()),
-		}));
+		})));
 
 		let base_url2 = "https://node2.logion.network".as_bytes().to_vec();
-		assert_err!(LoAuthorityList::add_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID2, LegalOfficerData {
+		assert_err!(LoAuthorityList::add_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID2, LegalOfficerData::Host(HostData {
 			base_url: Option::Some(base_url2.clone()),
 			node_id: Option::Some(node_id1.clone()),
-		}), Error::<Test>::PeerIdAlreadyInUse);
+		})), Error::<Test>::PeerIdAlreadyInUse);
 	});
 }
 
@@ -130,25 +150,25 @@ fn it_fails_update_if_peer_id_already_in_use() {
 	new_test_ext().execute_with(|| {
 		let base_url1 = "https://node1.logion.network".as_bytes().to_vec();
 		let node_id1 = OpaquePeerId(bs58::decode("12D3KooWBmAwcd4PJNJvfV89HwE48nwkRmAgo8Vy3uQEyNNHBox2").into_vec().unwrap());
-		assert_ok!(LoAuthorityList::add_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID, LegalOfficerData {
+		assert_ok!(LoAuthorityList::add_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID, LegalOfficerData::Host(HostData {
 			node_id: Option::Some(node_id1.clone()),
 			base_url: Option::Some(base_url1.clone()),
-		}));
+		})));
 
 		let base_url2 = "https://node2.logion.network".as_bytes().to_vec();
 		let node_id2 = OpaquePeerId(bs58::decode("12D3KooWQYV9dGMFoRzNStwpXztXaBUjtPqi6aU76ZgUriHhKust").into_vec().unwrap());
-		assert_ok!(LoAuthorityList::add_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID2, LegalOfficerData {
+		assert_ok!(LoAuthorityList::add_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID2, LegalOfficerData::Host(HostData {
 			base_url: Option::Some(base_url2.clone()),
 			node_id: Option::Some(node_id2.clone()),
-		}));
+		})));
 		assert_eq!(LoAuthorityList::legal_officer_nodes().len(), 2);
 		assert!(LoAuthorityList::legal_officer_nodes().contains(&node_id1));
 		assert!(LoAuthorityList::legal_officer_nodes().contains(&node_id2));
 
-		assert_err!(LoAuthorityList::update_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID2, LegalOfficerData {
+		assert_err!(LoAuthorityList::update_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID2, LegalOfficerData::Host(HostData {
 			base_url: Option::Some(base_url2.clone()),
 			node_id: Option::Some(node_id1.clone()),
-		}), Error::<Test>::PeerIdAlreadyInUse);
+		})), Error::<Test>::PeerIdAlreadyInUse);
 	});
 }
 
@@ -157,10 +177,10 @@ fn it_updates_nodes_on_remove() {
 	new_test_ext().execute_with(|| {
 		let base_url = "https://node.logion.network".as_bytes().to_vec();
 		let node_id = OpaquePeerId(bs58::decode("12D3KooWBmAwcd4PJNJvfV89HwE48nwkRmAgo8Vy3uQEyNNHBox2").into_vec().unwrap());
-		assert_ok!(LoAuthorityList::add_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID, LegalOfficerData {
+		assert_ok!(LoAuthorityList::add_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID, LegalOfficerData::Host(HostData {
 			node_id: Option::Some(node_id.clone()),
 			base_url: Option::Some(base_url.clone()),
-		}));
+		})));
 		assert_ok!(LoAuthorityList::remove_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID));
 		assert!(LoAuthorityList::legal_officer_nodes().is_empty());
 	});
@@ -171,17 +191,135 @@ fn it_updates_nodes_on_update() {
 	new_test_ext().execute_with(|| {
 		let base_url = "https://node.logion.network".as_bytes().to_vec();
 		let node_id1 = OpaquePeerId(bs58::decode("12D3KooWBmAwcd4PJNJvfV89HwE48nwkRmAgo8Vy3uQEyNNHBox2").into_vec().unwrap());
-		assert_ok!(LoAuthorityList::add_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID, LegalOfficerData {
+		assert_ok!(LoAuthorityList::add_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID, LegalOfficerData::Host(HostData {
 			node_id: Option::Some(node_id1.clone()),
 			base_url: Option::Some(base_url.clone()),
-		}));
+		})));
 		let node_id2 = OpaquePeerId(bs58::decode("12D3KooWQYV9dGMFoRzNStwpXztXaBUjtPqi6aU76ZgUriHhKust").into_vec().unwrap());
-		assert_ok!(LoAuthorityList::update_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID, LegalOfficerData {
+		assert_ok!(LoAuthorityList::update_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID, LegalOfficerData::Host(HostData {
 			node_id: Option::Some(node_id2.clone()),
 			base_url: Option::Some(base_url.clone()),
-		}));
+		})));
 
 		assert_eq!(LoAuthorityList::legal_officer_nodes().len(), 1);
 		assert!(LoAuthorityList::legal_officer_nodes().contains(&node_id2));
+	});
+}
+
+#[test]
+fn it_adds_guest() {
+	new_test_ext().execute_with(|| {
+		setup_host_and_guest();
+		assert!(LoAuthorityList::legal_officer_set(LEGAL_OFFICER_ID2).is_some());
+		assert_eq!(LoAuthorityList::legal_officer_nodes().len(), 1);
+	});
+}
+
+fn setup_host_and_guest() {
+	let host_data = LegalOfficerData::Host(HostData {
+		node_id: Option::Some(OpaquePeerId(bs58::decode("12D3KooWBmAwcd4PJNJvfV89HwE48nwkRmAgo8Vy3uQEyNNHBox2").into_vec().unwrap())),
+		base_url: Option::Some("https://node.logion.network".as_bytes().to_vec()),
+	});
+	assert_ok!(LoAuthorityList::add_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID, host_data));
+	assert_ok!(LoAuthorityList::add_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID2, LegalOfficerData::Guest(LEGAL_OFFICER_ID)));
+}
+
+#[test]
+fn it_removes_guest() {
+	new_test_ext().execute_with(|| {
+		setup_host_and_guest();
+		assert_ok!(LoAuthorityList::remove_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID2));
+		assert!(LoAuthorityList::legal_officer_set(LEGAL_OFFICER_ID2).is_none());
+		assert_eq!(LoAuthorityList::legal_officer_nodes().len(), 1);
+	});
+}
+
+#[test]
+fn it_turns_guest_into_host() {
+	new_test_ext().execute_with(|| {
+		setup_host_and_guest();
+		let host_data2 = LegalOfficerData::Host(HostData {
+			node_id: Option::Some(OpaquePeerId(bs58::decode("12D3KooWQYV9dGMFoRzNStwpXztXaBUjtPqi6aU76ZgUriHhKust").into_vec().unwrap())),
+			base_url: Option::Some("https://node2.logion.network".as_bytes().to_vec()),
+		});
+		assert_ok!(LoAuthorityList::update_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID2, host_data2));
+		assert!(LoAuthorityList::legal_officer_set(LEGAL_OFFICER_ID2).is_some());
+		assert_eq!(LoAuthorityList::legal_officer_nodes().len(), 2);
+	});
+}
+
+#[test]
+fn it_turns_host_into_guest() {
+	new_test_ext().execute_with(|| {
+		setup_hosts();
+		assert_ok!(LoAuthorityList::update_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID2, LegalOfficerData::Guest(LEGAL_OFFICER_ID)));
+		assert!(LoAuthorityList::legal_officer_set(LEGAL_OFFICER_ID2).is_some());
+		assert_eq!(LoAuthorityList::legal_officer_nodes().len(), 1);
+	});
+}
+
+fn setup_hosts() {
+	let host_data = LegalOfficerData::Host(HostData {
+		node_id: Option::Some(OpaquePeerId(bs58::decode("12D3KooWBmAwcd4PJNJvfV89HwE48nwkRmAgo8Vy3uQEyNNHBox2").into_vec().unwrap())),
+		base_url: Option::Some("https://node1.logion.network".as_bytes().to_vec()),
+	});
+	assert_ok!(LoAuthorityList::add_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID, host_data));
+	let host_data2 = LegalOfficerData::Host(HostData {
+		node_id: Option::Some(OpaquePeerId(bs58::decode("12D3KooWQYV9dGMFoRzNStwpXztXaBUjtPqi6aU76ZgUriHhKust").into_vec().unwrap())),
+		base_url: Option::Some("https://node2.logion.network".as_bytes().to_vec()),
+	});
+	assert_ok!(LoAuthorityList::add_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID2, host_data2));
+}
+
+#[test]
+fn it_fails_turning_host_with_guest_into_guest() {
+	new_test_ext().execute_with(|| {
+		setup_host_and_guest();
+		let host_data3 = LegalOfficerData::Host(HostData {
+			node_id: Option::Some(OpaquePeerId(bs58::decode("12D3KooWJvyP3VJYymTqG7eH4PM5rN4T2agk5cdNCfNymAqwqcvZ").into_vec().unwrap())),
+			base_url: Option::Some("https://node3.logion.network".as_bytes().to_vec()),
+		});
+		assert_ok!(LoAuthorityList::add_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID3, host_data3));
+		assert_err!(LoAuthorityList::update_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID, LegalOfficerData::Guest(LEGAL_OFFICER_ID3)),
+			Error::<Test>::HostHasGuest);
+	});
+}
+
+#[test]
+fn it_fails_removing_host_with_guests() {
+	new_test_ext().execute_with(|| {
+		setup_host_and_guest();
+		assert_err!(LoAuthorityList::remove_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID), Error::<Test>::HostHasGuest);
+	});
+}
+
+#[test]
+fn it_fails_adding_guest_with_guest() {
+	new_test_ext().execute_with(|| {
+		setup_host_and_guest();
+		assert_err!(LoAuthorityList::add_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID3, LegalOfficerData::Guest(LEGAL_OFFICER_ID2)),
+			Error::<Test>::GuestOfGuest);
+	});
+}
+
+#[test]
+fn it_fails_adding_guest_with_unknown_host() {
+	new_test_ext().execute_with(|| {
+		let host_data = LegalOfficerData::Host(HostData {
+			node_id: Option::Some(OpaquePeerId(bs58::decode("12D3KooWBmAwcd4PJNJvfV89HwE48nwkRmAgo8Vy3uQEyNNHBox2").into_vec().unwrap())),
+			base_url: Option::Some("https://node.logion.network".as_bytes().to_vec()),
+		});
+		assert_ok!(LoAuthorityList::add_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID, host_data));
+		assert_err!(LoAuthorityList::add_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID2, LegalOfficerData::Guest(LEGAL_OFFICER_ID3)),
+			Error::<Test>::HostNotFound);
+	});
+}
+
+#[test]
+fn it_fails_if_guest_updates() {
+	new_test_ext().execute_with(|| {
+		setup_host_and_guest();
+		assert_err!(LoAuthorityList::update_legal_officer(RuntimeOrigin::signed(LEGAL_OFFICER_ID2), LEGAL_OFFICER_ID2, LegalOfficerData::Guest(LEGAL_OFFICER_ID)),
+			Error::<Test>::GuestCannotUpdate);
 	});
 }


### PR DESCRIPTION
* Hosts may have any number of guests
* Hosts may update their info but not turn themselves into guests (only superuser can do that)
* Guests cannot update anything (only superuser can)
* Hosts can be removed or turned into a guest only once they have no guests left

logion-network/logion-internal#699