### PR TITLE
Add Guest LLO when vote is approved

### DIFF
--- a/logion-shared/src/lib.rs
+++ b/logion-shared/src/lib.rs
@@ -1,10 +1,11 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use frame_support::{
+    dispatch::{GetDispatchInfo, Vec, Weight},
     Parameter,
-    dispatch::{Weight, GetDispatchInfo, Vec},
-    traits::{UnfilteredDispatchable, EnsureOrigin},
+    traits::{EnsureOrigin, UnfilteredDispatchable},
 };
+use frame_support::dispatch::DispatchResultWithPostInfo;
 use frame_system::{ensure_signed, RawOrigin};
 use sp_std::boxed::Box;
 
@@ -14,8 +15,14 @@ pub trait CreateRecoveryCallFactory<Origin, AccountId, BlockNumber> {
     fn build_create_recovery_call(legal_officers: Vec<AccountId>, threshold: u16, delay_period: BlockNumber) -> Self::Call;
 }
 
-pub trait LocQuery<AccountId> {
+pub struct LegalOfficerCaseSummary<AccountId> {
+    pub owner: AccountId,
+    pub requester: Option<AccountId>,
+}
+
+pub trait LocQuery<LocId, AccountId> {
     fn has_closed_identity_locs(account: &AccountId, legal_officer: &Vec<AccountId>) -> bool;
+    fn get_loc(loc_id: &LocId) -> Option<LegalOfficerCaseSummary<AccountId>>;
 }
 
 pub trait LocValidity<LocId, AccountId> {
@@ -66,4 +73,11 @@ pub trait IsLegalOfficer<AccountId: PartialEq, Origin: Clone + Into<Result<RawOr
     }
 
     fn legal_officers() -> Vec<AccountId>;
+}
+
+pub trait LegalOfficerCreation<AccountId> {
+    fn add_guest_legal_officer(
+        guest_legal_officer_id: AccountId,
+        host_legal_officer_id: AccountId,
+    ) -> DispatchResultWithPostInfo;
 }

--- a/pallet-logion-vote/src/tests.rs
+++ b/pallet-logion-vote/src/tests.rs
@@ -22,7 +22,7 @@ fn it_creates_vote() {
                 ]
             }));
         assert_eq!(LogionVote::votes(2), None);
-        assert_eq!(LogionVote::is_vote_completed(vote_id), (false, false))
+        assert_eq!(LogionVote::is_vote_closed_and_approved(vote_id), (false, false))
     });
 }
 
@@ -59,7 +59,7 @@ fn it_votes_yes() {
                     Ballot { voter: LEGAL_OFFICER2, status: BallotStatus::NotVoted },
                 ]
             }));
-        assert_eq!(LogionVote::is_vote_completed(vote_id), (false, false))
+        assert_eq!(LogionVote::is_vote_closed_and_approved(vote_id), (false, false))
     });
 }
 
@@ -79,7 +79,7 @@ fn it_votes_yes_and_no() {
                     Ballot { voter: LEGAL_OFFICER2, status: BallotStatus::VotedNo },
                 ]
             }));
-        assert_eq!(LogionVote::is_vote_completed(vote_id), (true, false))
+        assert_eq!(LogionVote::is_vote_closed_and_approved(vote_id), (true, false))
     });
 }
 
@@ -99,7 +99,7 @@ fn it_votes_yes_and_yes() {
                     Ballot { voter: LEGAL_OFFICER2, status: BallotStatus::VotedYes },
                 ]
             }));
-        assert_eq!(LogionVote::is_vote_completed(vote_id), (true, true))
+        assert_eq!(LogionVote::is_vote_closed_and_approved(vote_id), (true, true))
     });
 }
 

--- a/pallet-logion-vote/src/tests.rs
+++ b/pallet-logion-vote/src/tests.rs
@@ -10,14 +10,14 @@ const WALLET_USER: u64 = 100;
 fn it_creates_vote() {
     new_test_ext().execute_with(|| {
         assert_empty_storage();
-        assert_ok!(LogionVote::create_vote_for_all_legal_officers(RuntimeOrigin::signed(LEGAL_OFFICER1), LOC_ID));
+        assert_ok!(LogionVote::create_vote_for_all_legal_officers(RuntimeOrigin::signed(HOST_LEGAL_OFFICER), LOC_ID));
         let vote_id = LogionVote::last_vote_id();
         assert_eq!(vote_id, 1);
         assert_eq!(LogionVote::votes(1), Some(
             Vote {
                 loc_id: LOC_ID,
                 ballots: vec![
-                    Ballot { voter: LEGAL_OFFICER1, status: BallotStatus::NotVoted },
+                    Ballot { voter: HOST_LEGAL_OFFICER, status: BallotStatus::NotVoted },
                     Ballot { voter: LEGAL_OFFICER2, status: BallotStatus::NotVoted },
                 ]
             }));
@@ -39,7 +39,7 @@ fn it_fails_to_create_vote_when_not_legal_officer() {
 fn it_fails_to_create_vote_when_wrong_loc() {
     new_test_ext().execute_with(|| {
         assert_empty_storage();
-        assert_err!(LogionVote::create_vote_for_all_legal_officers(RuntimeOrigin::signed(LEGAL_OFFICER1), WRONG_LOC_ID), Error::<Test>::InvalidLoc);
+        assert_err!(LogionVote::create_vote_for_all_legal_officers(RuntimeOrigin::signed(HOST_LEGAL_OFFICER), WRONG_LOC_ID), Error::<Test>::InvalidLoc);
         assert_empty_storage();
     });
 }
@@ -48,14 +48,14 @@ fn it_fails_to_create_vote_when_wrong_loc() {
 fn it_votes_yes() {
     new_test_ext().execute_with(|| {
         assert_empty_storage();
-        assert_ok!(LogionVote::create_vote_for_all_legal_officers(RuntimeOrigin::signed(LEGAL_OFFICER1), LOC_ID));
+        assert_ok!(LogionVote::create_vote_for_all_legal_officers(RuntimeOrigin::signed(HOST_LEGAL_OFFICER), LOC_ID));
         let vote_id: u64 = LogionVote::last_vote_id();
-        assert_ok!(LogionVote::vote(RuntimeOrigin::signed(LEGAL_OFFICER1), vote_id, true));
+        assert_ok!(LogionVote::vote(RuntimeOrigin::signed(HOST_LEGAL_OFFICER), vote_id, true));
         assert_eq!(LogionVote::votes(vote_id), Some(
             Vote {
                 loc_id: LOC_ID,
                 ballots: vec![
-                    Ballot { voter: LEGAL_OFFICER1, status: BallotStatus::VotedYes },
+                    Ballot { voter: HOST_LEGAL_OFFICER, status: BallotStatus::VotedYes },
                     Ballot { voter: LEGAL_OFFICER2, status: BallotStatus::NotVoted },
                 ]
             }));
@@ -67,15 +67,15 @@ fn it_votes_yes() {
 fn it_votes_yes_and_no() {
     new_test_ext().execute_with(|| {
         assert_empty_storage();
-        assert_ok!(LogionVote::create_vote_for_all_legal_officers(RuntimeOrigin::signed(LEGAL_OFFICER1), LOC_ID));
+        assert_ok!(LogionVote::create_vote_for_all_legal_officers(RuntimeOrigin::signed(HOST_LEGAL_OFFICER), LOC_ID));
         let vote_id: u64 = LogionVote::last_vote_id();
-        assert_ok!(LogionVote::vote(RuntimeOrigin::signed(LEGAL_OFFICER1), vote_id, true));
+        assert_ok!(LogionVote::vote(RuntimeOrigin::signed(HOST_LEGAL_OFFICER), vote_id, true));
         assert_ok!(LogionVote::vote(RuntimeOrigin::signed(LEGAL_OFFICER2), vote_id, false));
         assert_eq!(LogionVote::votes(vote_id), Some(
             Vote {
                 loc_id: LOC_ID,
                 ballots: vec![
-                    Ballot { voter: LEGAL_OFFICER1, status: BallotStatus::VotedYes },
+                    Ballot { voter: HOST_LEGAL_OFFICER, status: BallotStatus::VotedYes },
                     Ballot { voter: LEGAL_OFFICER2, status: BallotStatus::VotedNo },
                 ]
             }));
@@ -87,15 +87,15 @@ fn it_votes_yes_and_no() {
 fn it_votes_yes_and_yes() {
     new_test_ext().execute_with(|| {
         assert_empty_storage();
-        assert_ok!(LogionVote::create_vote_for_all_legal_officers(RuntimeOrigin::signed(LEGAL_OFFICER1), LOC_ID));
+        assert_ok!(LogionVote::create_vote_for_all_legal_officers(RuntimeOrigin::signed(HOST_LEGAL_OFFICER), LOC_ID));
         let vote_id: u64 = LogionVote::last_vote_id();
-        assert_ok!(LogionVote::vote(RuntimeOrigin::signed(LEGAL_OFFICER1), vote_id, true));
+        assert_ok!(LogionVote::vote(RuntimeOrigin::signed(HOST_LEGAL_OFFICER), vote_id, true));
         assert_ok!(LogionVote::vote(RuntimeOrigin::signed(LEGAL_OFFICER2), vote_id, true));
         assert_eq!(LogionVote::votes(vote_id), Some(
             Vote {
                 loc_id: LOC_ID,
                 ballots: vec![
-                    Ballot { voter: LEGAL_OFFICER1, status: BallotStatus::VotedYes },
+                    Ballot { voter: HOST_LEGAL_OFFICER, status: BallotStatus::VotedYes },
                     Ballot { voter: LEGAL_OFFICER2, status: BallotStatus::VotedYes },
                 ]
             }));
@@ -107,7 +107,7 @@ fn it_votes_yes_and_yes() {
 fn it_fails_to_vote_wrong_vote_id() {
     new_test_ext().execute_with(|| {
         assert_empty_storage();
-        assert_ok!(LogionVote::create_vote_for_all_legal_officers(RuntimeOrigin::signed(LEGAL_OFFICER1), LOC_ID));
+        assert_ok!(LogionVote::create_vote_for_all_legal_officers(RuntimeOrigin::signed(HOST_LEGAL_OFFICER), LOC_ID));
         let wrong_vote_id: u64 = LogionVote::last_vote_id() + 100;
         assert_err!(LogionVote::vote(RuntimeOrigin::signed(LEGAL_OFFICER2), wrong_vote_id, false), Error::<Test>::VoteNotFound);
     });
@@ -117,7 +117,7 @@ fn it_fails_to_vote_wrong_vote_id() {
 fn it_fails_to_vote_wrong_voter() {
     new_test_ext().execute_with(|| {
         assert_empty_storage();
-        assert_ok!(LogionVote::create_vote_for_all_legal_officers(RuntimeOrigin::signed(LEGAL_OFFICER1), LOC_ID));
+        assert_ok!(LogionVote::create_vote_for_all_legal_officers(RuntimeOrigin::signed(HOST_LEGAL_OFFICER), LOC_ID));
         let vote_id: u64 = LogionVote::last_vote_id();
         assert_err!(LogionVote::vote(RuntimeOrigin::signed(WALLET_USER), vote_id, true), Error::<Test>::NotAllowed);
     });
@@ -127,7 +127,7 @@ fn it_fails_to_vote_wrong_voter() {
 fn it_fails_to_vote_twice() {
     new_test_ext().execute_with(|| {
         assert_empty_storage();
-        assert_ok!(LogionVote::create_vote_for_all_legal_officers(RuntimeOrigin::signed(LEGAL_OFFICER1), LOC_ID));
+        assert_ok!(LogionVote::create_vote_for_all_legal_officers(RuntimeOrigin::signed(HOST_LEGAL_OFFICER), LOC_ID));
         let vote_id: u64 = LogionVote::last_vote_id();
         assert_ok!(LogionVote::vote(RuntimeOrigin::signed(LEGAL_OFFICER2), vote_id, false));
         assert_err!(LogionVote::vote(RuntimeOrigin::signed(LEGAL_OFFICER2), vote_id, true), Error::<Test>::AlreadyVoted);

--- a/pallet-verified-recovery/src/lib.rs
+++ b/pallet-verified-recovery/src/lib.rs
@@ -12,6 +12,7 @@ pub mod weights;
 
 #[frame_support::pallet]
 pub mod pallet {
+    use codec::HasCompact;
     use frame_system::pallet_prelude::*;
     use frame_support::{
         dispatch::DispatchResultWithPostInfo,
@@ -25,11 +26,14 @@ pub mod pallet {
     #[pallet::config]
     pub trait Config: frame_system::Config {
 
+        /// LOC identifier
+        type LocId: Member + Parameter + Default + Copy + HasCompact;
+
         /// Implementation of recovery config creation
         type CreateRecoveryCallFactory: CreateRecoveryCallFactory<Self::RuntimeOrigin, Self::AccountId, Self::BlockNumber>;
 
         /// Query for checking the existence of a closed Identity LOC
-        type LocQuery: LocQuery<Self::AccountId>;
+        type LocQuery: LocQuery<Self::LocId, Self::AccountId>;
 
         /// Weight information for extrinsics in this pallet.
         type WeightInfo: WeightInfo;

--- a/pallet-verified-recovery/src/mock.rs
+++ b/pallet-verified-recovery/src/mock.rs
@@ -1,5 +1,5 @@
 use crate::{self as pallet_verified_recovery};
-use logion_shared::{LocQuery, CreateRecoveryCallFactory};
+use logion_shared::{LocQuery, CreateRecoveryCallFactory, LegalOfficerCaseSummary};
 use sp_core::hash::H256;
 use frame_support::{parameter_types};
 use sp_runtime::{
@@ -69,16 +69,21 @@ pub const LEGAL_OFFICER_PENDING_OR_OPEN_ID2: u64 = 4;
 pub const USER_ID: u64 = 5;
 
 pub struct LocQueryMock;
-impl LocQuery<<Test as system::Config>::AccountId> for LocQueryMock {
+impl LocQuery<<Test as pallet_verified_recovery::Config>::LocId, <Test as system::Config>::AccountId> for LocQueryMock {
     fn has_closed_identity_locs(
         account: &<Test as system::Config>::AccountId,
         legal_officers: &Vec<<Test as system::Config>::AccountId>
     ) -> bool {
         return *account == USER_ID && legal_officers[0] == LEGAL_OFFICER_CLOSED_ID1 && legal_officers[1] == LEGAL_OFFICER_CLOSED_ID2;
     }
+
+    fn get_loc(_loc_id: &<Test as pallet_verified_recovery::Config>::LocId) -> Option<LegalOfficerCaseSummary<<Test as system::Config>::AccountId>> {
+        return None;
+    }
 }
 
 impl pallet_verified_recovery::Config for Test {
+    type LocId = u32;
     type CreateRecoveryCallFactory = CreateRecoveryCallFactoryMock;
     type LocQuery = LocQueryMock;
     type RuntimeEvent = RuntimeEvent;


### PR DESCRIPTION
* A vote is `closed` when all LO's have voted.
* A vote is `approved` when it's `closed`, and if all LO's have voted `Yes`.
* When a vote is `approved`, the Identity LOC, subject of the vote, is fetched.
* The requester of that LOC becomes new Guest LLO - his/her Host being the owner of the same LOC.