### PR TITLE
Emit event upon Storage Fee withdrawal.

### DIFF
--- a/pallet-logion-loc/src/lib.rs
+++ b/pallet-logion-loc/src/lib.rs
@@ -358,6 +358,8 @@ pub mod pallet {
         LocVoid(T::LocId),
         /// Issued when an item was added to a collection. [locId, collectionItemId]
         ItemAdded(T::LocId, T::CollectionItemId),
+        /// Issued when File Storage Fee is withdrawn. [payerAccountId, storageFee]
+        StorageFeeWithdrawn(T::AccountId, BalanceOf<T>)
     }
 
     #[pallet::error]
@@ -1340,6 +1342,7 @@ pub mod pallet {
             ensure!(T::Currency::can_slash(&fee_payer, fee), Error::<T>::InsufficientFunds);
             let (credit, _) = T::Currency::slash(&fee_payer, fee);
             T::FileStorageFeeDistributor::distribute(credit, T::FileStorageFeeDistributionKey::get());
+            Self::deposit_event(Event::StorageFeeWithdrawn(fee_payer, fee));
             Ok(())
         }
 

--- a/pallet-logion-loc/src/mock.rs
+++ b/pallet-logion-loc/src/mock.rs
@@ -172,7 +172,7 @@ impl pallet_loc::Config for Test {
 
 // Build genesis storage according to the mock runtime.
 pub fn new_test_ext() -> sp_io::TestExternalities {
-    system::GenesisConfig::default().build_storage::<Test>().unwrap().into()
+    new_test_ext_at_block(1)
 }
 
 pub fn new_test_ext_at_block(block_number: u64) -> sp_io::TestExternalities {

--- a/pallet-logion-loc/src/tests.rs
+++ b/pallet-logion-loc/src/tests.rs
@@ -1575,6 +1575,10 @@ fn check_fees(num_of_files: u32, tot_size: u32, payer: AccountId) {
     assert_eq!(credited_fees, expected_fees);
     let actual_fees = BALANCE_OK_FOR_FILES - get_free_balance(payer);
     assert_eq!(actual_fees, expected_fees);
+    System::assert_has_event(RuntimeEvent::LogionLoc(crate::Event::StorageFeeWithdrawn {
+        0: payer,
+        1: expected_fees,
+    }));
 }
 
 fn check_no_fees(payer: AccountId) {


### PR DESCRIPTION
Emit event upon Storage Fee withdrawal: `StorageFeeWithdrawn(payer, amount)`


logion-network/logion-internal#830