### PR TITLE
Upgrade to polkadot-v0.9.40.

### DIFF
--- a/logion-shared/Cargo.toml
+++ b/logion-shared/Cargo.toml
@@ -14,9 +14,9 @@ keywords = ['logion']
 targets = ['x86_64-unknown-linux-gnu']
 
 [dependencies]
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.39" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.39" }
-sp-std = { git = "https://github.com/paritytech/substrate.git", default-features = false, branch = "polkadot-v0.9.39" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
+sp-std = { git = "https://github.com/paritytech/substrate.git", default-features = false, branch = "polkadot-v0.9.40" }
 
 [features]
 default = ['std']

--- a/pallet-block-reward/Cargo.toml
+++ b/pallet-block-reward/Cargo.toml
@@ -15,22 +15,22 @@ targets = ['x86_64-unknown-linux-gnu']
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "max-encoded-len"] }
-frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.39" }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.39" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.39" }
+frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.40" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
 log = { version = "0.4.14", default-features = false }
 logion-shared = { path = "../logion-shared", default-features = false }
 scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
 serde = { version = "1.0.137", optional = true, features = ["derive"] }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.39" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.39" }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.39" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
 
 [dev-dependencies]
 bs58 = "0.4.0"
-pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.39" }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.39" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.39" }
+pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
 
 [features]
 default = ['std']

--- a/pallet-lo-authority-list/Cargo.toml
+++ b/pallet-lo-authority-list/Cargo.toml
@@ -15,20 +15,20 @@ targets = ['x86_64-unknown-linux-gnu']
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "max-encoded-len"] }
-frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.39" }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.39" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.39" }
+frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.40" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
 log = { version = "0.4.14", default-features = false }
 logion-shared = { path = "../logion-shared", default-features = false }
 scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
 serde = { version = "1.0.137", optional = true, features = ["derive"] }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.39" }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.39" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
 
 [dev-dependencies]
 bs58 = "0.4.0"
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.39" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.39" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
 
 [features]
 default = ['std']

--- a/pallet-lo-authority-list/src/lib.rs
+++ b/pallet-lo-authority-list/src/lib.rs
@@ -72,7 +72,6 @@ pub mod pallet {
     }
 
     #[pallet::pallet]
-    #[pallet::generate_store(pub(super) trait Store)]
     #[pallet::without_storage_info]
     pub struct Pallet<T>(_);
 

--- a/pallet-logion-loc/Cargo.toml
+++ b/pallet-logion-loc/Cargo.toml
@@ -15,21 +15,21 @@ targets = ['x86_64-unknown-linux-gnu']
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.2.1", default-features = false, features = ["derive", "max-encoded-len"] }
-frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.39" }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.39" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.39" }
+frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.40" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
 log = { version = "0.4.14", default-features = false }
 logion-shared = { path = "../logion-shared", default-features = false }
 scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.39" }
-sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.39" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.39" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
+sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
 
 [dev-dependencies]
 serde = { version = "1.0.137", features = ["derive"] }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.39" }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.39" }
-pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.39" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
+pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
 
 [features]
 default = ['std']

--- a/pallet-logion-loc/src/lib.rs
+++ b/pallet-logion-loc/src/lib.rs
@@ -276,7 +276,6 @@ pub mod pallet {
     }
 
     #[pallet::pallet]
-    #[pallet::generate_store(pub(super) trait Store)]
     #[pallet::without_storage_info]
     pub struct Pallet<T>(_);
 

--- a/pallet-logion-loc/src/weights.rs
+++ b/pallet-logion-loc/src/weights.rs
@@ -59,82 +59,82 @@ pub trait WeightInfo {
 pub struct SubstrateWeight<T>(PhantomData<T>);
 impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
     fn create_polkadot_identity_loc() -> Weight {
-        Weight::from_ref_time(29_862_000)
+        Weight::from_parts(29_862_000, 0)
             .saturating_add(T::DbWeight::get().reads(3))
             .saturating_add(T::DbWeight::get().writes(2))
     }
     fn create_logion_identity_loc() -> Weight {
-        Weight::from_ref_time(20_945_000)
+        Weight::from_parts(20_945_000, 0)
             .saturating_add(T::DbWeight::get().reads(2))
             .saturating_add(T::DbWeight::get().writes(1))
     }
     fn create_polkadot_transaction_loc() -> Weight {
-        Weight::from_ref_time(26_316_000)
+        Weight::from_parts(26_316_000, 0)
             .saturating_add(T::DbWeight::get().reads(3))
             .saturating_add(T::DbWeight::get().writes(2))
     }
     fn create_logion_transaction_loc() -> Weight {
-        Weight::from_ref_time(30_288_000)
+        Weight::from_parts(30_288_000, 0)
             .saturating_add(T::DbWeight::get().reads(4))
             .saturating_add(T::DbWeight::get().writes(2))
     }
     fn add_metadata() -> Weight {
-        Weight::from_ref_time(11_979_000)
+        Weight::from_parts(11_979_000, 0)
             .saturating_add(T::DbWeight::get().reads(1))
             .saturating_add(T::DbWeight::get().writes(1))
     }
     fn add_file() -> Weight {
-        Weight::from_ref_time(11_971_000)
+        Weight::from_parts(11_971_000, 0)
             .saturating_add(T::DbWeight::get().reads(1))
             .saturating_add(T::DbWeight::get().writes(1))
     }
     fn add_link() -> Weight {
-        Weight::from_ref_time(16_067_000)
+        Weight::from_parts(16_067_000, 0)
             .saturating_add(T::DbWeight::get().reads(2))
             .saturating_add(T::DbWeight::get().writes(1))
     }
     fn close() -> Weight {
-        Weight::from_ref_time(22_224_000)
+        Weight::from_parts(22_224_000, 0)
             .saturating_add(T::DbWeight::get().reads(1))
             .saturating_add(T::DbWeight::get().writes(1))
     }
     fn make_void() -> Weight {
-        Weight::from_ref_time(22_360_000)
+        Weight::from_parts(22_360_000, 0)
             .saturating_add(T::DbWeight::get().reads(1))
             .saturating_add(T::DbWeight::get().writes(1))
     }
     fn make_void_and_replace() -> Weight {
-        Weight::from_ref_time(32_724_000)
+        Weight::from_parts(32_724_000, 0)
             .saturating_add(T::DbWeight::get().reads(2))
             .saturating_add(T::DbWeight::get().writes(2))
     }
     fn create_collection_loc() -> Weight {
-        Weight::from_ref_time(29_219_000)
+        Weight::from_parts(29_219_000, 0)
             .saturating_add(T::DbWeight::get().reads(3))
             .saturating_add(T::DbWeight::get().writes(2))
     }
     fn add_collection_item() -> Weight {
-        Weight::from_ref_time(31_621_000)
+        Weight::from_parts(31_621_000, 0)
             .saturating_add(T::DbWeight::get().reads(3))
             .saturating_add(T::DbWeight::get().writes(2))
     }
     fn nominate_issuer() -> Weight {
-      Weight::from_ref_time(11_971_000)
+      Weight::from_parts(11_971_000, 0)
             .saturating_add(T::DbWeight::get().reads(1))
             .saturating_add(T::DbWeight::get().writes(1))
     }
     fn dismiss_issuer() -> Weight {
-      Weight::from_ref_time(11_971_000)
+      Weight::from_parts(11_971_000, 0)
             .saturating_add(T::DbWeight::get().reads(1))
             .saturating_add(T::DbWeight::get().writes(1))
     }
     fn set_issuer_selection() -> Weight {
-        Weight::from_ref_time(11_971_000)
+        Weight::from_parts(11_971_000, 0)
             .saturating_add(T::DbWeight::get().reads(1))
             .saturating_add(T::DbWeight::get().writes(1))
     }
     fn add_tokens_record() -> Weight {
-        Weight::from_ref_time(31_621_000)
+        Weight::from_parts(31_621_000, 0)
             .saturating_add(T::DbWeight::get().reads(3))
             .saturating_add(T::DbWeight::get().writes(2))
     }
@@ -143,82 +143,82 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 // For backwards compatibility and tests
 impl WeightInfo for () {
   fn create_polkadot_identity_loc() -> Weight {
-    Weight::from_ref_time(29_862_000)
+    Weight::from_parts(29_862_000, 0)
       .saturating_add(RocksDbWeight::get().reads(3))
       .saturating_add(RocksDbWeight::get().writes(2))
   }
   fn create_logion_identity_loc() -> Weight {
-    Weight::from_ref_time(20_945_000)
+    Weight::from_parts(20_945_000, 0)
       .saturating_add(RocksDbWeight::get().reads(2))
       .saturating_add(RocksDbWeight::get().writes(1))
   }
   fn create_polkadot_transaction_loc() -> Weight {
-    Weight::from_ref_time(26_316_000)
+    Weight::from_parts(26_316_000, 0)
       .saturating_add(RocksDbWeight::get().reads(3))
       .saturating_add(RocksDbWeight::get().writes(2))
   }
   fn create_logion_transaction_loc() -> Weight {
-    Weight::from_ref_time(30_288_000)
+    Weight::from_parts(30_288_000, 0)
       .saturating_add(RocksDbWeight::get().reads(4))
       .saturating_add(RocksDbWeight::get().writes(2))
   }
   fn add_metadata() -> Weight {
-    Weight::from_ref_time(11_979_000)
+    Weight::from_parts(11_979_000, 0)
       .saturating_add(RocksDbWeight::get().reads(1))
       .saturating_add(RocksDbWeight::get().writes(1))
   }
   fn add_file() -> Weight {
-    Weight::from_ref_time(11_971_000)
+    Weight::from_parts(11_971_000, 0)
       .saturating_add(RocksDbWeight::get().reads(1))
       .saturating_add(RocksDbWeight::get().writes(1))
   }
   fn add_link() -> Weight {
-    Weight::from_ref_time(16_067_000)
+    Weight::from_parts(16_067_000, 0)
       .saturating_add(RocksDbWeight::get().reads(2))
       .saturating_add(RocksDbWeight::get().writes(1))
   }
   fn close() -> Weight {
-    Weight::from_ref_time(22_224_000)
+    Weight::from_parts(22_224_000, 0)
       .saturating_add(RocksDbWeight::get().reads(1))
       .saturating_add(RocksDbWeight::get().writes(1))
   }
   fn make_void() -> Weight {
-    Weight::from_ref_time(22_360_000)
+    Weight::from_parts(22_360_000, 0)
       .saturating_add(RocksDbWeight::get().reads(1))
       .saturating_add(RocksDbWeight::get().writes(1))
   }
   fn make_void_and_replace() -> Weight {
-    Weight::from_ref_time(32_724_000)
+    Weight::from_parts(32_724_000, 0)
       .saturating_add(RocksDbWeight::get().reads(2))
       .saturating_add(RocksDbWeight::get().writes(2))
   }
   fn create_collection_loc() -> Weight {
-    Weight::from_ref_time(29_219_000)
+    Weight::from_parts(29_219_000, 0)
       .saturating_add(RocksDbWeight::get().reads(3))
       .saturating_add(RocksDbWeight::get().writes(2))
   }
   fn add_collection_item() -> Weight {
-    Weight::from_ref_time(31_621_000)
+    Weight::from_parts(31_621_000, 0)
       .saturating_add(RocksDbWeight::get().reads(3))
       .saturating_add(RocksDbWeight::get().writes(2))
   }
   fn nominate_issuer() -> Weight {
-    Weight::from_ref_time(11_971_000)
+    Weight::from_parts(11_971_000, 0)
       .saturating_add(RocksDbWeight::get().reads(1))
       .saturating_add(RocksDbWeight::get().writes(1))
   }
   fn dismiss_issuer() -> Weight {
-    Weight::from_ref_time(11_971_000)
+    Weight::from_parts(11_971_000, 0)
       .saturating_add(RocksDbWeight::get().reads(1))
       .saturating_add(RocksDbWeight::get().writes(1))
   }
   fn set_issuer_selection() -> Weight {
-    Weight::from_ref_time(11_971_000)
+    Weight::from_parts(11_971_000, 0)
       .saturating_add(RocksDbWeight::get().reads(1))
       .saturating_add(RocksDbWeight::get().writes(1))
   }
   fn add_tokens_record() -> Weight {
-    Weight::from_ref_time(31_621_000)
+    Weight::from_parts(31_621_000, 0)
       .saturating_add(RocksDbWeight::get().reads(3))
       .saturating_add(RocksDbWeight::get().writes(2))
 }

--- a/pallet-logion-vault/Cargo.toml
+++ b/pallet-logion-vault/Cargo.toml
@@ -14,19 +14,19 @@ targets = ['x86_64-unknown-linux-gnu']
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.2.1", default-features = false, features = ["derive", "max-encoded-len"] }
-frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.39" }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.39" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.39" }
+frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.40" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
 logion-shared = { path = "../logion-shared", default-features = false }
-pallet-multisig = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.39" }
+pallet-multisig = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
 scale-info = { version = "2.2.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.145", features = ["derive"] }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.39" }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.39" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
 
 [dev-dependencies]
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.39" }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.39" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
 
 [features]
 default = ['std']

--- a/pallet-logion-vault/src/lib.rs
+++ b/pallet-logion-vault/src/lib.rs
@@ -49,7 +49,6 @@ pub mod pallet {
     }
 
     #[pallet::pallet]
-    #[pallet::generate_store(pub(super) trait Store)]
     pub struct Pallet<T>(_);
 
     #[pallet::event]

--- a/pallet-logion-vault/src/tests.rs
+++ b/pallet-logion-vault/src/tests.rs
@@ -8,7 +8,7 @@ use sp_runtime::traits::Hash;
 fn it_requests_call_if_not_legal_officer() {
     new_test_ext().execute_with(|| {
         let call_hash = BlakeTwo256::hash_of(&"call-bytes".as_bytes().to_vec());
-        assert_ok!(Vault::request_call(RuntimeOrigin::signed(USER_ID), vec![LEGAL_OFFICER1, LEGAL_OFFICER2], call_hash.to_fixed_bytes(), Weight::from_ref_time(10000)));
+        assert_ok!(Vault::request_call(RuntimeOrigin::signed(USER_ID), vec![LEGAL_OFFICER1, LEGAL_OFFICER2], call_hash.to_fixed_bytes(), Weight::from_parts(10000, 0)));
     });
 }
 
@@ -16,7 +16,7 @@ fn it_requests_call_if_not_legal_officer() {
 fn it_fails_requesting_call_if_legal_officer() {
     new_test_ext().execute_with(|| {
         let call_hash = BlakeTwo256::hash_of(&"call-bytes".as_bytes().to_vec());
-        assert_err!(Vault::request_call(RuntimeOrigin::signed(LEGAL_OFFICER1), vec![LEGAL_OFFICER1, LEGAL_OFFICER2], call_hash.to_fixed_bytes(), Weight::from_ref_time(10000)), Error::<Test>::WrongInitiator);
+        assert_err!(Vault::request_call(RuntimeOrigin::signed(LEGAL_OFFICER1), vec![LEGAL_OFFICER1, LEGAL_OFFICER2], call_hash.to_fixed_bytes(), Weight::from_parts(10000, 0)), Error::<Test>::WrongInitiator);
     });
 }
 
@@ -24,7 +24,7 @@ fn it_fails_requesting_call_if_legal_officer() {
 fn it_fails_requesting_call_if_not_two_legal_officers() {
     new_test_ext().execute_with(|| {
         let call_hash = BlakeTwo256::hash_of(&"call-bytes".as_bytes().to_vec());
-        assert_err!(Vault::request_call(RuntimeOrigin::signed(USER_ID), vec![LEGAL_OFFICER1], call_hash.to_fixed_bytes(), Weight::from_ref_time(10000)), Error::<Test>::InvalidSignatories);
+        assert_err!(Vault::request_call(RuntimeOrigin::signed(USER_ID), vec![LEGAL_OFFICER1], call_hash.to_fixed_bytes(), Weight::from_parts(10000, 0)), Error::<Test>::InvalidSignatories);
     });
 }
 
@@ -32,7 +32,7 @@ fn it_fails_requesting_call_if_not_two_legal_officers() {
 fn it_fails_requesting_call_if_not_all_legal_officers() {
     new_test_ext().execute_with(|| {
         let call_hash = BlakeTwo256::hash_of(&"call-bytes".as_bytes().to_vec());
-        assert_err!(Vault::request_call(RuntimeOrigin::signed(USER_ID), vec![LEGAL_OFFICER1, ANOTHER_USER_ID], call_hash.to_fixed_bytes(), Weight::from_ref_time(10000)), Error::<Test>::InvalidSignatories);
+        assert_err!(Vault::request_call(RuntimeOrigin::signed(USER_ID), vec![LEGAL_OFFICER1, ANOTHER_USER_ID], call_hash.to_fixed_bytes(), Weight::from_parts(10000, 0)), Error::<Test>::InvalidSignatories);
     });
 }
 
@@ -41,6 +41,6 @@ fn it_approves_call_if_two_other_signatories() {
     new_test_ext().execute_with(|| {
         let call = Box::new(RuntimeCall::System(frame_system::Call::remark{ remark : Vec::from([0u8]) }));
         let timepoint = Default::default();
-        assert_ok!(Vault::approve_call(RuntimeOrigin::signed(LEGAL_OFFICER1), vec![USER_ID, LEGAL_OFFICER2], call, timepoint, Weight::from_ref_time(10000)));
+        assert_ok!(Vault::approve_call(RuntimeOrigin::signed(LEGAL_OFFICER1), vec![USER_ID, LEGAL_OFFICER2], call, timepoint, Weight::from_parts(10000, 0)));
     });
 }

--- a/pallet-logion-vote/Cargo.toml
+++ b/pallet-logion-vote/Cargo.toml
@@ -14,19 +14,19 @@ targets = ['x86_64-unknown-linux-gnu']
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.2.1", default-features = false, features = ["derive", "max-encoded-len"] }
-frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.39" }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.39" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.39" }
+frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.40" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
 log = { version = "0.4.14", default-features = false }
 logion-shared = { path = "../logion-shared", default-features = false }
 scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.39" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
 
 [dev-dependencies]
 serde = { version = "1.0.137", features = ["derive"] }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.39" }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.39" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.39" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
 
 [features]
 default = ['std']

--- a/pallet-logion-vote/src/lib.rs
+++ b/pallet-logion-vote/src/lib.rs
@@ -70,7 +70,6 @@ pub mod pallet {
     }
 
     #[pallet::pallet]
-    #[pallet::generate_store(pub (super) trait Store)]
     #[pallet::without_storage_info]
     pub struct Pallet<T>(_);
 

--- a/pallet-verified-recovery/Cargo.toml
+++ b/pallet-verified-recovery/Cargo.toml
@@ -15,18 +15,18 @@ targets = ['x86_64-unknown-linux-gnu']
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.2.1", default-features = false, features = ["derive", "max-encoded-len"] }
-frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.39" }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.39" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.39" }
+frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.40" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
 logion-shared = { path = "../logion-shared", default-features = false }
 scale-info = { version = "2.2.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.145", features = ["derive"] }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.39" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
 
 [dev-dependencies]
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.39" }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.39" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.39" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
 
 [features]
 default = ['std']

--- a/pallet-verified-recovery/src/lib.rs
+++ b/pallet-verified-recovery/src/lib.rs
@@ -43,7 +43,6 @@ pub mod pallet {
     }
 
     #[pallet::pallet]
-    #[pallet::generate_store(pub(super) trait Store)]
     pub struct Pallet<T>(_);
 
     #[pallet::event]

--- a/pallet-verified-recovery/src/weights.rs
+++ b/pallet-verified-recovery/src/weights.rs
@@ -14,7 +14,7 @@ pub trait WeightInfo {
 pub struct DefaultWeight<T>(PhantomData<T>);
 impl<T: frame_system::Config> WeightInfo for DefaultWeight<T> {
     fn create_recovery() -> Weight {
-        Weight::from_ref_time(33_904_000)
+        Weight::from_parts(33_904_000, 0)
             .saturating_add(T::DbWeight::get().reads(2))
             .saturating_add(T::DbWeight::get().writes(1))
     }
@@ -22,7 +22,7 @@ impl<T: frame_system::Config> WeightInfo for DefaultWeight<T> {
 
 impl WeightInfo for () {
     fn create_recovery() -> Weight {
-        Weight::from_ref_time(33_904_000)
+        Weight::from_parts(33_904_000, 0)
             .saturating_add(RocksDbWeight::get().reads(2))
             .saturating_add(RocksDbWeight::get().writes(1))
     }


### PR DESCRIPTION
* Upgrade to [polkadot-v0.9.40](https://github.com/paritytech/polkadot/releases/tag/v0.9.40)
* Remove useless `trait Store` - see https://github.com/paritytech/substrate/pull/13535
* Change deprecated `Weight::from_ref_time(n)` into `Weight::from_parts(n, 0)`.

logion-network/logion-internal#835