### PR TITLE
Add ethereum address for Identity LOC requester

### DIFF
--- a/pallet-logion-loc/Cargo.toml
+++ b/pallet-logion-loc/Cargo.toml
@@ -24,10 +24,10 @@ scale-info = { version = "2.1.1", default-features = false, features = ["derive"
 sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
 sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
 sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
 
 [dev-dependencies]
 serde = { version = "1.0.137", features = ["derive"] }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
 sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
 pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
 
@@ -44,6 +44,7 @@ std = [
 	'pallet-balances/std',
 	"sp-api/std",
 	"sp-runtime/std",
+	"sp-core/std",
 ]
 runtime-benchmarks = [
 	'frame-benchmarking',

--- a/pallet-logion-loc/Cargo.toml
+++ b/pallet-logion-loc/Cargo.toml
@@ -24,10 +24,10 @@ scale-info = { version = "2.1.1", default-features = false, features = ["derive"
 sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
 sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
 sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
 
 [dev-dependencies]
 serde = { version = "1.0.137", features = ["derive"] }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
 sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
 pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
 
@@ -44,7 +44,6 @@ std = [
 	'pallet-balances/std',
 	"sp-api/std",
 	"sp-runtime/std",
-	"sp-core/std",
 ]
 runtime-benchmarks = [
 	'frame-benchmarking',

--- a/pallet-logion-loc/src/migrations.rs
+++ b/pallet-logion-loc/src/migrations.rs
@@ -20,9 +20,9 @@ pub mod v10 {
     type FileV9Of<T> = FileV9<<T as pallet::Config>::Hash, <T as frame_system::Config>::AccountId>;
 
     #[derive(Encode, Decode, Default, Clone, PartialEq, Eq, Debug, TypeInfo)]
-    pub struct LegalOfficerCaseV9<AccountId, Hash, LocId, BlockNumber> {
+    pub struct LegalOfficerCaseV9<AccountId, Hash, LocId, BlockNumber, EthereumAddress> {
         owner: AccountId,
-        requester: Requester<AccountId, LocId>,
+        requester: Requester<AccountId, LocId, EthereumAddress>,
         metadata: Vec<MetadataItem<AccountId>>,
         files: Vec<FileV9<Hash, AccountId>>,
         closed: bool,
@@ -36,7 +36,13 @@ pub mod v10 {
         seal: Option<Hash>,
     }
 
-    type LegalOfficerCaseOfV9<T> = LegalOfficerCaseV9<<T as frame_system::Config>::AccountId, <T as pallet::Config>::Hash, <T as pallet::Config>::LocId, <T as frame_system::Config>::BlockNumber>;
+    type LegalOfficerCaseOfV9<T> = LegalOfficerCaseV9<
+        <T as frame_system::Config>::AccountId,
+        <T as pallet::Config>::Hash,
+        <T as pallet::Config>::LocId,
+        <T as frame_system::Config>::BlockNumber,
+        <T as pallet::Config>::EthereumAddress,
+    >;
 
     pub struct AddSizeToLocFile<T>(sp_std::marker::PhantomData<T>);
 

--- a/pallet-logion-loc/src/mock.rs
+++ b/pallet-logion-loc/src/mock.rs
@@ -4,12 +4,14 @@ use sp_core::hash::H256;
 use frame_support::{construct_runtime, parameter_types, traits::{EnsureOrigin, Currency}};
 use sp_runtime::{traits::{BlakeTwo256, IdentityLookup}, testing::Header, Percent};
 use frame_system as system;
+use sp_core::H160;
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 
 pub type AccountId = u64;
 pub type Balance = u128;
+pub type EthereumAddress = H160;
 
 construct_runtime!(
     pub struct Test where
@@ -168,6 +170,7 @@ impl pallet_loc::Config for Test {
     type FileStorageEntryFee = FileStorageEntryFee;
     type FileStorageFeeDistributor = RewardDistributorImpl;
     type FileStorageFeeDistributionKey = RewardDistributionKey;
+    type EthereumAddress = H160;
 }
 
 // Build genesis storage according to the mock runtime.

--- a/pallet-logion-loc/src/tests.rs
+++ b/pallet-logion-loc/src/tests.rs
@@ -8,7 +8,7 @@ use sp_runtime::traits::Hash;
 
 use logion_shared::{LocQuery, LocValidity};
 
-use crate::{Error, File, LegalOfficerCase, LocLink, LocType, MetadataItem, CollectionItem, CollectionItemFile, CollectionItemToken, mock::*, TermsAndConditionsElement, TokensRecordFile, UnboundedTokensRecordFileOf, VerifiedIssuer, Config, OtherAccountId, EthereumAddress};
+use crate::{Error, File, LegalOfficerCase, LocLink, LocType, MetadataItem, CollectionItem, CollectionItemFile, CollectionItemToken, mock::*, TermsAndConditionsElement, TokensRecordFile, UnboundedTokensRecordFileOf, VerifiedIssuer, Config, OtherAccountId};
 use crate::Requester::OtherAccount;
 
 const LOC_ID: u32 = 0;

--- a/pallet-logion-loc/src/weights.rs
+++ b/pallet-logion-loc/src/weights.rs
@@ -53,10 +53,12 @@ pub trait WeightInfo {
     fn dismiss_issuer() -> Weight;
     fn set_issuer_selection() -> Weight;
     fn add_tokens_record() -> Weight;
+    fn create_other_identity_loc() -> Weight;
 }
 
 /// Weights for pallet_logion_loc using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);
+
 impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
     fn create_polkadot_identity_loc() -> Weight {
         Weight::from_parts(29_862_000, 0)
@@ -119,12 +121,12 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
             .saturating_add(T::DbWeight::get().writes(2))
     }
     fn nominate_issuer() -> Weight {
-      Weight::from_parts(11_971_000, 0)
+        Weight::from_parts(11_971_000, 0)
             .saturating_add(T::DbWeight::get().reads(1))
             .saturating_add(T::DbWeight::get().writes(1))
     }
     fn dismiss_issuer() -> Weight {
-      Weight::from_parts(11_971_000, 0)
+        Weight::from_parts(11_971_000, 0)
             .saturating_add(T::DbWeight::get().reads(1))
             .saturating_add(T::DbWeight::get().writes(1))
     }
@@ -138,88 +140,98 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
             .saturating_add(T::DbWeight::get().reads(3))
             .saturating_add(T::DbWeight::get().writes(2))
     }
+    fn create_other_identity_loc() -> Weight {
+        Weight::from_parts(20_945_000, 0)
+            .saturating_add(T::DbWeight::get().reads(2))
+            .saturating_add(T::DbWeight::get().writes(1))
+    }
 }
 
 // For backwards compatibility and tests
 impl WeightInfo for () {
-  fn create_polkadot_identity_loc() -> Weight {
-    Weight::from_parts(29_862_000, 0)
-      .saturating_add(RocksDbWeight::get().reads(3))
-      .saturating_add(RocksDbWeight::get().writes(2))
-  }
-  fn create_logion_identity_loc() -> Weight {
-    Weight::from_parts(20_945_000, 0)
-      .saturating_add(RocksDbWeight::get().reads(2))
-      .saturating_add(RocksDbWeight::get().writes(1))
-  }
-  fn create_polkadot_transaction_loc() -> Weight {
-    Weight::from_parts(26_316_000, 0)
-      .saturating_add(RocksDbWeight::get().reads(3))
-      .saturating_add(RocksDbWeight::get().writes(2))
-  }
-  fn create_logion_transaction_loc() -> Weight {
-    Weight::from_parts(30_288_000, 0)
-      .saturating_add(RocksDbWeight::get().reads(4))
-      .saturating_add(RocksDbWeight::get().writes(2))
-  }
-  fn add_metadata() -> Weight {
-    Weight::from_parts(11_979_000, 0)
-      .saturating_add(RocksDbWeight::get().reads(1))
-      .saturating_add(RocksDbWeight::get().writes(1))
-  }
-  fn add_file() -> Weight {
-    Weight::from_parts(11_971_000, 0)
-      .saturating_add(RocksDbWeight::get().reads(1))
-      .saturating_add(RocksDbWeight::get().writes(1))
-  }
-  fn add_link() -> Weight {
-    Weight::from_parts(16_067_000, 0)
-      .saturating_add(RocksDbWeight::get().reads(2))
-      .saturating_add(RocksDbWeight::get().writes(1))
-  }
-  fn close() -> Weight {
-    Weight::from_parts(22_224_000, 0)
-      .saturating_add(RocksDbWeight::get().reads(1))
-      .saturating_add(RocksDbWeight::get().writes(1))
-  }
-  fn make_void() -> Weight {
-    Weight::from_parts(22_360_000, 0)
-      .saturating_add(RocksDbWeight::get().reads(1))
-      .saturating_add(RocksDbWeight::get().writes(1))
-  }
-  fn make_void_and_replace() -> Weight {
-    Weight::from_parts(32_724_000, 0)
-      .saturating_add(RocksDbWeight::get().reads(2))
-      .saturating_add(RocksDbWeight::get().writes(2))
-  }
-  fn create_collection_loc() -> Weight {
-    Weight::from_parts(29_219_000, 0)
-      .saturating_add(RocksDbWeight::get().reads(3))
-      .saturating_add(RocksDbWeight::get().writes(2))
-  }
-  fn add_collection_item() -> Weight {
-    Weight::from_parts(31_621_000, 0)
-      .saturating_add(RocksDbWeight::get().reads(3))
-      .saturating_add(RocksDbWeight::get().writes(2))
-  }
-  fn nominate_issuer() -> Weight {
-    Weight::from_parts(11_971_000, 0)
-      .saturating_add(RocksDbWeight::get().reads(1))
-      .saturating_add(RocksDbWeight::get().writes(1))
-  }
-  fn dismiss_issuer() -> Weight {
-    Weight::from_parts(11_971_000, 0)
-      .saturating_add(RocksDbWeight::get().reads(1))
-      .saturating_add(RocksDbWeight::get().writes(1))
-  }
-  fn set_issuer_selection() -> Weight {
-    Weight::from_parts(11_971_000, 0)
-      .saturating_add(RocksDbWeight::get().reads(1))
-      .saturating_add(RocksDbWeight::get().writes(1))
-  }
-  fn add_tokens_record() -> Weight {
-    Weight::from_parts(31_621_000, 0)
-      .saturating_add(RocksDbWeight::get().reads(3))
-      .saturating_add(RocksDbWeight::get().writes(2))
-}
+    fn create_polkadot_identity_loc() -> Weight {
+        Weight::from_parts(29_862_000, 0)
+            .saturating_add(RocksDbWeight::get().reads(3))
+            .saturating_add(RocksDbWeight::get().writes(2))
+    }
+    fn create_logion_identity_loc() -> Weight {
+        Weight::from_parts(20_945_000, 0)
+            .saturating_add(RocksDbWeight::get().reads(2))
+            .saturating_add(RocksDbWeight::get().writes(1))
+    }
+    fn create_polkadot_transaction_loc() -> Weight {
+        Weight::from_parts(26_316_000, 0)
+            .saturating_add(RocksDbWeight::get().reads(3))
+            .saturating_add(RocksDbWeight::get().writes(2))
+    }
+    fn create_logion_transaction_loc() -> Weight {
+        Weight::from_parts(30_288_000, 0)
+            .saturating_add(RocksDbWeight::get().reads(4))
+            .saturating_add(RocksDbWeight::get().writes(2))
+    }
+    fn add_metadata() -> Weight {
+        Weight::from_parts(11_979_000, 0)
+            .saturating_add(RocksDbWeight::get().reads(1))
+            .saturating_add(RocksDbWeight::get().writes(1))
+    }
+    fn add_file() -> Weight {
+        Weight::from_parts(11_971_000, 0)
+            .saturating_add(RocksDbWeight::get().reads(1))
+            .saturating_add(RocksDbWeight::get().writes(1))
+    }
+    fn add_link() -> Weight {
+        Weight::from_parts(16_067_000, 0)
+            .saturating_add(RocksDbWeight::get().reads(2))
+            .saturating_add(RocksDbWeight::get().writes(1))
+    }
+    fn close() -> Weight {
+        Weight::from_parts(22_224_000, 0)
+            .saturating_add(RocksDbWeight::get().reads(1))
+            .saturating_add(RocksDbWeight::get().writes(1))
+    }
+    fn make_void() -> Weight {
+        Weight::from_parts(22_360_000, 0)
+            .saturating_add(RocksDbWeight::get().reads(1))
+            .saturating_add(RocksDbWeight::get().writes(1))
+    }
+    fn make_void_and_replace() -> Weight {
+        Weight::from_parts(32_724_000, 0)
+            .saturating_add(RocksDbWeight::get().reads(2))
+            .saturating_add(RocksDbWeight::get().writes(2))
+    }
+    fn create_collection_loc() -> Weight {
+        Weight::from_parts(29_219_000, 0)
+            .saturating_add(RocksDbWeight::get().reads(3))
+            .saturating_add(RocksDbWeight::get().writes(2))
+    }
+    fn add_collection_item() -> Weight {
+        Weight::from_parts(31_621_000, 0)
+            .saturating_add(RocksDbWeight::get().reads(3))
+            .saturating_add(RocksDbWeight::get().writes(2))
+    }
+    fn nominate_issuer() -> Weight {
+        Weight::from_parts(11_971_000, 0)
+            .saturating_add(RocksDbWeight::get().reads(1))
+            .saturating_add(RocksDbWeight::get().writes(1))
+    }
+    fn dismiss_issuer() -> Weight {
+        Weight::from_parts(11_971_000, 0)
+            .saturating_add(RocksDbWeight::get().reads(1))
+            .saturating_add(RocksDbWeight::get().writes(1))
+    }
+    fn set_issuer_selection() -> Weight {
+        Weight::from_parts(11_971_000, 0)
+            .saturating_add(RocksDbWeight::get().reads(1))
+            .saturating_add(RocksDbWeight::get().writes(1))
+    }
+    fn add_tokens_record() -> Weight {
+        Weight::from_parts(31_621_000, 0)
+            .saturating_add(RocksDbWeight::get().reads(3))
+            .saturating_add(RocksDbWeight::get().writes(2))
+    }
+    fn create_other_identity_loc() -> Weight {
+        Weight::from_parts(20_945_000, 0)
+            .saturating_add(RocksDbWeight::get().reads(2))
+            .saturating_add(RocksDbWeight::get().writes(1))
+    }
 }


### PR DESCRIPTION
* Allow to create an identity LOC whose requester is another (non-polkadot) account.
* Currently only Ethereum Address is supported.