### PR TITLE
Sponsorship creation/withdrawal

### DIFF
--- a/pallet-logion-loc/src/mock.rs
+++ b/pallet-logion-loc/src/mock.rs
@@ -12,6 +12,7 @@ type Block = frame_system::mocking::MockBlock<Test>;
 pub type AccountId = u64;
 pub type Balance = u128;
 pub type EthereumAddress = H160;
+pub type SponsorshipId = u32;
 
 construct_runtime!(
     pub struct Test where
@@ -81,6 +82,7 @@ pub const LOC_REQUESTER: RequesterOf<Test> = RequesterOf::<Test>::Account(LOC_RE
 pub const LOGION_IDENTITY_LOC_ID: u32 = 4;
 pub const ISSUER_ID1: u64 = 5;
 pub const ISSUER_ID2: u64 = 6;
+pub const SPONSOR_ID: u64 = 7;
 
 pub struct LoAuthorityListMock;
 impl EnsureOrigin<RuntimeOrigin> for LoAuthorityListMock {
@@ -170,7 +172,8 @@ impl pallet_loc::Config for Test {
     type FileStorageEntryFee = FileStorageEntryFee;
     type FileStorageFeeDistributor = RewardDistributorImpl;
     type FileStorageFeeDistributionKey = RewardDistributionKey;
-    type EthereumAddress = H160;
+    type EthereumAddress = EthereumAddress;
+    type SponsorshipId = SponsorshipId;
 }
 
 // Build genesis storage according to the mock runtime.

--- a/pallet-logion-loc/src/tests.rs
+++ b/pallet-logion-loc/src/tests.rs
@@ -1668,3 +1668,35 @@ fn it_adds_file_when_submitter_is_ethereum_requester() {
         check_fees(1, file.size, LOC_OWNER1);
     });
 }
+
+#[test]
+fn it_creates_sponsorship() {
+    new_test_ext().execute_with(|| {
+        let sponsorship_id = 1;
+        let beneficiary = H160::from_str("0x900edc98db53508e6742723988b872dd08cd09c2").unwrap();
+        let sponsored_account = SupportedAccountId::Other(OtherAccountId::Ethereum(beneficiary));
+
+        assert_ok!(LogionLoc::sponsor(RuntimeOrigin::signed(SPONSOR_ID), sponsorship_id, sponsored_account, LOC_OWNER1));
+
+        let sponsorship = LogionLoc::sponsorship(sponsorship_id).unwrap();
+        assert_eq!(sponsorship.legal_officer, LOC_OWNER1);
+        assert_eq!(sponsorship.sponsor, SPONSOR_ID);
+        assert_eq!(sponsorship.sponsored_account, sponsored_account);
+        assert_eq!(sponsorship.used, false);
+    });
+}
+
+#[test]
+fn it_withdraws_unused_sponsorship() {
+    new_test_ext().execute_with(|| {
+        let sponsorship_id = 1;
+        let beneficiary = H160::from_str("0x900edc98db53508e6742723988b872dd08cd09c2").unwrap();
+        let sponsored_account = SupportedAccountId::Other(OtherAccountId::Ethereum(beneficiary));
+        assert_ok!(LogionLoc::sponsor(RuntimeOrigin::signed(SPONSOR_ID), sponsorship_id, sponsored_account, LOC_OWNER1));
+        assert!(LogionLoc::sponsorship(sponsorship_id).is_some());
+
+        assert_ok!(LogionLoc::withdraw_sponsorship(RuntimeOrigin::signed(SPONSOR_ID), sponsorship_id));
+
+        assert!(LogionLoc::sponsorship(sponsorship_id).is_none());
+    });
+}

--- a/pallet-logion-loc/src/weights.rs
+++ b/pallet-logion-loc/src/weights.rs
@@ -54,6 +54,7 @@ pub trait WeightInfo {
     fn set_issuer_selection() -> Weight;
     fn add_tokens_record() -> Weight;
     fn create_other_identity_loc() -> Weight;
+    fn sponsor() -> Weight;
 }
 
 /// Weights for pallet_logion_loc using the Substrate node and recommended hardware.
@@ -145,6 +146,11 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
             .saturating_add(T::DbWeight::get().reads(2))
             .saturating_add(T::DbWeight::get().writes(1))
     }
+    fn sponsor() -> Weight {
+        Weight::from_parts(20_945_000, 0)
+            .saturating_add(T::DbWeight::get().reads(2))
+            .saturating_add(T::DbWeight::get().writes(1))
+    }
 }
 
 // For backwards compatibility and tests
@@ -230,6 +236,11 @@ impl WeightInfo for () {
             .saturating_add(RocksDbWeight::get().writes(2))
     }
     fn create_other_identity_loc() -> Weight {
+        Weight::from_parts(20_945_000, 0)
+            .saturating_add(RocksDbWeight::get().reads(2))
+            .saturating_add(RocksDbWeight::get().writes(1))
+    }
+    fn sponsor() -> Weight {
         Weight::from_parts(20_945_000, 0)
             .saturating_add(RocksDbWeight::get().reads(2))
             .saturating_add(RocksDbWeight::get().writes(1))


### PR DESCRIPTION
* Adds storage and management extrinsics.
* General process
  * Sponsor creates a sponsorship
  * As long as the sponsorship has not been used, it may be withdrawn
  * (not done yet) upon sponsored ID LOC creation, a sponsorship is marked as used and storage fees are withdrawn from sponsor account

logion-network/logion-internal#860