### PR TITLE
Enable requester or issuer to publish File; Acknowledge by LO.

### DIFF
--- a/pallet-logion-loc/src/benchmarking.rs
+++ b/pallet-logion-loc/src/benchmarking.rs
@@ -43,7 +43,7 @@ benchmarks! {
     add_file {
         let caller = <T as crate::Config>::CreateOrigin::successful_origin().into().ok().unwrap();
         let loc_id = Default::default();
-        let file = File {
+        let file = FileParams {
             hash: Default::default(),
             nature: vec![1u8, 2u8, 3u8],
             submitter: Default::default(),

--- a/pallet-logion-loc/src/lib.rs
+++ b/pallet-logion-loc/src/lib.rs
@@ -65,6 +65,15 @@ pub struct File<Hash, AccountId, EthereumAddress> {
     nature: Vec<u8>,
     submitter: SupportedAccountId<AccountId, EthereumAddress>,
     size: u32,
+    acknowledged: bool,
+}
+
+#[derive(Encode, Decode, Default, Clone, PartialEq, Eq, Debug, TypeInfo)]
+pub struct FileParams<Hash, AccountId, EthereumAddress> {
+    hash: Hash,
+    nature: Vec<u8>,
+    submitter: SupportedAccountId<AccountId, EthereumAddress>,
+    size: u32,
 }
 
 #[derive(Encode, Decode, Clone, PartialEq, Eq, Debug, TypeInfo)]
@@ -731,8 +740,8 @@ pub mod pallet {
                 let loc = <LocMap<T>>::get(&loc_id).unwrap();
                 let submitted_by_owner: bool = loc.owner == who;
                 if !submitted_by_owner && (
-                    !Self::can_submit(&loc_id, &loc, &SupportedAccountId::Polkadot(who.clone())) ||
-                        item.submitter != SupportedAccountId::Polkadot(who)
+                    item.submitter != SupportedAccountId::Polkadot(who) ||
+                    !Self::can_submit(&loc_id, &loc, &item.submitter)
                 ) {
                     Err(Error::<T>::Unauthorized)?
                 } else if loc.closed {
@@ -765,7 +774,7 @@ pub mod pallet {
         pub fn add_file(
             origin: OriginFor<T>,
             #[pallet::compact] loc_id: T::LocId,
-            file: File<<T as pallet::Config>::Hash, T::AccountId, T::EthereumAddress>
+            file: FileParams<<T as pallet::Config>::Hash, T::AccountId, T::EthereumAddress>
         ) -> DispatchResultWithPostInfo {
             let who = ensure_signed(origin)?;
 
@@ -777,7 +786,11 @@ pub mod pallet {
                 Err(Error::<T>::NotFound)?
             } else {
                 let loc = <LocMap<T>>::get(&loc_id).unwrap();
-                if loc.owner != who {
+                let submitted_by_owner: bool = loc.owner == who;
+                if !submitted_by_owner && (
+                    file.submitter != SupportedAccountId::Polkadot(who) ||
+                        !Self::can_submit(&loc_id, &loc, &file.submitter)
+                ) {
                     Err(Error::<T>::Unauthorized)?
                 } else if loc.closed {
                     Err(Error::<T>::CannotMutate)?
@@ -802,7 +815,13 @@ pub mod pallet {
                     Self::apply_file_storage_fee(fee_payer, 1, file.size)?;
                     <LocMap<T>>::mutate(loc_id, |loc| {
                         let mutable_loc = loc.as_mut().unwrap();
-                        mutable_loc.files.push(file);
+                        mutable_loc.files.push(File {
+                            hash: file.hash,
+                            nature: file.nature,
+                            submitter: file.submitter,
+                            size: file.size,
+                            acknowledged: submitted_by_owner,
+                        });
                     });
                     Ok(().into())
                 }
@@ -1189,6 +1208,40 @@ pub mod pallet {
                     <LocMap<T>>::mutate(loc_id, |loc| {
                         let mutable_loc = loc.as_mut().unwrap();
                         mutable_loc.metadata[item_index].acknowledged = true;
+                    });
+                    Ok(().into())
+                }
+            }
+        }
+
+        /// Acknowledge a file.
+        #[pallet::call_index(22)]
+        #[pallet::weight(T::WeightInfo::acknowledge_file())]
+        pub fn acknowledge_file(
+            origin: OriginFor<T>,
+            #[pallet::compact] loc_id: T::LocId,
+            hash: <T as pallet::Config>::Hash,
+        ) -> DispatchResultWithPostInfo {
+            let who = T::IsLegalOfficer::ensure_origin(origin.clone())?;
+
+            if !<LocMap<T>>::contains_key(&loc_id) {
+                Err(Error::<T>::NotFound)?
+            } else {
+                let loc = <LocMap<T>>::get(&loc_id).unwrap();
+                if loc.owner != who {
+                    Err(Error::<T>::Unauthorized)?
+                }
+                let option_item_index = loc.files.iter().position(|item| item.hash == hash);
+                if option_item_index.is_none() {
+                    Err(Error::<T>::ItemNotFound)?
+                } else {
+                    let item_index = option_item_index.unwrap();
+                    if loc.files[item_index].acknowledged {
+                        Err(Error::<T>::ItemAlreadyAcknowledged)?
+                    }
+                    <LocMap<T>>::mutate(loc_id, |loc| {
+                        let mutable_loc = loc.as_mut().unwrap();
+                        mutable_loc.files[item_index].acknowledged = true;
                     });
                     Ok(().into())
                 }

--- a/pallet-logion-loc/src/lib.rs
+++ b/pallet-logion-loc/src/lib.rs
@@ -558,11 +558,12 @@ pub mod pallet {
         V10AddLocFileSize,
         V11EnableEthereumSubmitter,
         V12Sponsorship,
+        V13AcknowledgeItems,
     }
 
     impl Default for StorageVersion {
         fn default() -> StorageVersion {
-            return StorageVersion::V11EnableEthereumSubmitter;
+            return StorageVersion::V12Sponsorship;
         }
     }
 

--- a/pallet-logion-loc/src/lib.rs
+++ b/pallet-logion-loc/src/lib.rs
@@ -1197,6 +1197,10 @@ pub mod pallet {
                 let loc = <LocMap<T>>::get(&loc_id).unwrap();
                 if loc.owner != who {
                     Err(Error::<T>::Unauthorized)?
+                } else if loc.closed {
+                    Err(Error::<T>::CannotMutate)?
+                } else if loc.void_info.is_some() {
+                    Err(Error::<T>::CannotMutateVoid)?
                 }
                 let option_item_index = loc.metadata.iter().position(|item| item.name == name);
                 if option_item_index.is_none() {
@@ -1231,6 +1235,10 @@ pub mod pallet {
                 let loc = <LocMap<T>>::get(&loc_id).unwrap();
                 if loc.owner != who {
                     Err(Error::<T>::Unauthorized)?
+                } else if loc.closed {
+                    Err(Error::<T>::CannotMutate)?
+                } else if loc.void_info.is_some() {
+                    Err(Error::<T>::CannotMutateVoid)?
                 }
                 let option_item_index = loc.files.iter().position(|item| item.hash == hash);
                 if option_item_index.is_none() {

--- a/pallet-logion-loc/src/migrations.rs
+++ b/pallet-logion-loc/src/migrations.rs
@@ -6,16 +6,35 @@ use frame_support::traits::OnRuntimeUpgrade;
 
 use crate::{Config, LegalOfficerCaseOf, PalletStorageVersion, pallet::StorageVersion};
 
-pub mod v12 {
+pub mod v13 {
     use super::*;
     use crate::*;
 
     #[derive(Encode, Decode, Default, Clone, PartialEq, Eq, Debug, TypeInfo)]
-    pub struct LegalOfficerCaseV11<AccountId, Hash, LocId, BlockNumber, EthereumAddress> {
+    pub struct MetadataItemV12<AccountId, EthereumAddress> {
+        name: Vec<u8>,
+        value: Vec<u8>,
+        submitter: SupportedAccountId<AccountId, EthereumAddress>,
+    }
+
+    type MetadataItemV12Of<T> = MetadataItemV12<<T as frame_system::Config>::AccountId, <T as pallet::Config>::EthereumAddress>;
+
+    #[derive(Encode, Decode, Default, Clone, PartialEq, Eq, Debug, TypeInfo)]
+    struct FileV12<Hash, AccountId, EthereumAddress> {
+        hash: Hash,
+        nature: Vec<u8>,
+        submitter: SupportedAccountId<AccountId, EthereumAddress>,
+        size: u32,
+    }
+
+    type FileV12Of<T> = FileV12<<T as pallet::Config>::Hash, <T as frame_system::Config>::AccountId, <T as pallet::Config>::EthereumAddress>;
+
+    #[derive(Encode, Decode, Default, Clone, PartialEq, Eq, Debug, TypeInfo)]
+    pub struct LegalOfficerCaseV12<AccountId, Hash, LocId, BlockNumber, EthereumAddress, SponsorshipId> {
         owner: AccountId,
         requester: Requester<AccountId, LocId, EthereumAddress>,
-        metadata: Vec<MetadataItem<AccountId, EthereumAddress>>,
-        files: Vec<File<Hash, AccountId, EthereumAddress>>,
+        metadata: Vec<MetadataItemV12<AccountId, EthereumAddress>>,
+        files: Vec<FileV12<Hash, AccountId, EthereumAddress>>,
         closed: bool,
         loc_type: LocType,
         links: Vec<LocLink<LocId>>,
@@ -25,31 +44,52 @@ pub mod v12 {
         collection_max_size: Option<CollectionSize>,
         collection_can_upload: bool,
         seal: Option<Hash>,
+        sponsorship_id: Option<SponsorshipId>,
     }
 
-    type LegalOfficerCaseV11Of<T> = LegalOfficerCaseV11<
+    type LegalOfficerCaseV12Of<T> = LegalOfficerCaseV12<
         <T as frame_system::Config>::AccountId,
         <T as pallet::Config>::Hash,
         <T as pallet::Config>::LocId,
         <T as frame_system::Config>::BlockNumber,
         <T as pallet::Config>::EthereumAddress,
+        <T as pallet::Config>::SponsorshipId,
     >;
 
-    pub struct AddSponsorship<T>(sp_std::marker::PhantomData<T>);
+    pub struct AddAcknowledgeItems<T>(sp_std::marker::PhantomData<T>);
 
-    impl<T: Config> OnRuntimeUpgrade for AddSponsorship<T> {
+    impl<T: Config> OnRuntimeUpgrade for AddAcknowledgeItems<T> {
         fn on_runtime_upgrade() -> Weight {
             super::do_storage_upgrade::<T, _>(
-                StorageVersion::V11EnableEthereumSubmitter,
                 StorageVersion::V12Sponsorship,
-                "AddSponsorship",
+                StorageVersion::V13AcknowledgeItems,
+                "AddAcknowledgeItems",
                 || {
-                    LocMap::<T>::translate_values(|loc: LegalOfficerCaseV11Of<T>| {
+                    LocMap::<T>::translate_values(|loc: LegalOfficerCaseV12Of<T>| {
+                        let files: Vec<File<<T as pallet::Config>::Hash, <T as frame_system::Config>::AccountId, T::EthereumAddress>> = loc.files
+                            .iter()
+                            .map(|file: &FileV12Of<T>| File {
+                                hash: file.hash,
+                                nature: file.nature.clone(),
+                                submitter: file.submitter.clone(),
+                                size: file.size,
+                                acknowledged: true,
+                            })
+                            .collect();
+                        let metadata: Vec<MetadataItem<<T as frame_system::Config>::AccountId, T::EthereumAddress>> = loc.metadata
+                            .iter()
+                            .map(|item: &MetadataItemV12Of<T>| MetadataItem {
+                                name: item.name.clone(),
+                                value: item.value.clone(),
+                                submitter: item.submitter.clone(),
+                                acknowledged: true,
+                            })
+                            .collect();
                         Some(LegalOfficerCaseOf::<T> {
                             owner: loc.owner,
                             requester: loc.requester,
-                            metadata: loc.metadata,
-                            files: loc.files,
+                            metadata,
+                            files,
                             closed: loc.closed,
                             loc_type: loc.loc_type,
                             links: loc.links,
@@ -69,7 +109,7 @@ pub mod v12 {
 }
 
 fn do_storage_upgrade<T: Config, F>(expected_version: StorageVersion, target_version: StorageVersion, migration_name: &str, migration: F) -> Weight
-where F: FnOnce() -> () {
+    where F: FnOnce() -> () {
     let storage_version = PalletStorageVersion::<T>::get();
     if storage_version == expected_version {
         migration();

--- a/pallet-logion-loc/src/tests.rs
+++ b/pallet-logion-loc/src/tests.rs
@@ -256,11 +256,10 @@ fn it_fails_to_acknowledge_metadata_when_unauthorized_caller() {
 }
 
 #[test]
-fn it_fails_to_acknowledge_metadata_when_loc_closed() {
+fn it_fails_to_close_loc_with_unacknowledged_metadata() {
     new_test_ext().execute_with(|| {
-        let metadata = create_loc_with_metadata_from_requester();
-        assert_ok!(LogionLoc::close(RuntimeOrigin::signed(LOC_OWNER1), LOC_ID));
-        assert_err!(LogionLoc::acknowledge_metadata(RuntimeOrigin::signed(LOC_OWNER1), LOC_ID, metadata.name.clone()), Error::<Test>::CannotMutate);
+        create_loc_with_metadata_from_requester();
+        assert_err!(LogionLoc::close(RuntimeOrigin::signed(LOC_OWNER1), LOC_ID), Error::<Test>::CannotCloseUnacknowledged);
     });
 }
 
@@ -472,11 +471,10 @@ fn it_fails_to_acknowledge_file_when_unauthorized_caller() {
 }
 
 #[test]
-fn it_fails_to_acknowledge_file_when_loc_closed() {
+fn it_fails_to_close_loc_with_unacknowledged_file() {
     new_test_ext().execute_with(|| {
-        let file = create_loc_with_file_from_requester();
-        assert_ok!(LogionLoc::close(RuntimeOrigin::signed(LOC_OWNER1), LOC_ID));
-        assert_err!(LogionLoc::acknowledge_file(RuntimeOrigin::signed(LOC_OWNER1), LOC_ID, file.hash.clone()), Error::<Test>::CannotMutate);
+        create_loc_with_file_from_requester();
+        assert_err!(LogionLoc::close(RuntimeOrigin::signed(LOC_OWNER1), LOC_ID), Error::<Test>::CannotCloseUnacknowledged);
     });
 }
 

--- a/pallet-logion-loc/src/tests.rs
+++ b/pallet-logion-loc/src/tests.rs
@@ -230,7 +230,7 @@ fn it_acknowledges_metadata() {
 }
 
 #[test]
-fn it_fails_to_acknowledges_unknown_metadata() {
+fn it_fails_to_acknowledge_unknown_metadata() {
     new_test_ext().execute_with(|| {
         create_loc_with_metadata_from_requester();
         let name = "unknown_metadata".as_bytes().to_vec();
@@ -239,7 +239,7 @@ fn it_fails_to_acknowledges_unknown_metadata() {
 }
 
 #[test]
-fn it_fails_to_acknowledges_already_acknowledged_metadata() {
+fn it_fails_to_acknowledge_already_acknowledged_metadata() {
     new_test_ext().execute_with(|| {
         let metadata = create_loc_with_metadata_from_requester();
         assert_ok!(LogionLoc::acknowledge_metadata(RuntimeOrigin::signed(LOC_OWNER1), LOC_ID, metadata.name.clone()));
@@ -248,10 +248,28 @@ fn it_fails_to_acknowledges_already_acknowledged_metadata() {
 }
 
 #[test]
-fn it_fails_to_acknowledges_metadata_when_unauthorized_caller() {
+fn it_fails_to_acknowledge_metadata_when_unauthorized_caller() {
     new_test_ext().execute_with(|| {
         let metadata = create_loc_with_metadata_from_requester();
         assert_err!(LogionLoc::acknowledge_metadata(RuntimeOrigin::signed(UNAUTHORIZED_CALLER), LOC_ID, metadata.name.clone()), BadOrigin);
+    });
+}
+
+#[test]
+fn it_fails_to_acknowledge_metadata_when_loc_closed() {
+    new_test_ext().execute_with(|| {
+        let metadata = create_loc_with_metadata_from_requester();
+        assert_ok!(LogionLoc::close(RuntimeOrigin::signed(LOC_OWNER1), LOC_ID));
+        assert_err!(LogionLoc::acknowledge_metadata(RuntimeOrigin::signed(LOC_OWNER1), LOC_ID, metadata.name.clone()), Error::<Test>::CannotMutate);
+    });
+}
+
+#[test]
+fn it_fails_to_acknowledge_metadata_when_loc_voided() {
+    new_test_ext().execute_with(|| {
+        let metadata = create_loc_with_metadata_from_requester();
+        assert_ok!(LogionLoc::make_void(RuntimeOrigin::signed(LOC_OWNER1), LOC_ID));
+        assert_err!(LogionLoc::acknowledge_metadata(RuntimeOrigin::signed(LOC_OWNER1), LOC_ID, metadata.name.clone()), Error::<Test>::CannotMutateVoid);
     });
 }
 
@@ -428,7 +446,7 @@ fn it_acknowledges_file() {
 }
 
 #[test]
-fn it_fails_to_acknowledges_unknown_file() {
+fn it_fails_to_acknowledge_unknown_file() {
     new_test_ext().execute_with(|| {
         create_loc_with_file_from_requester();
         let hash = BlakeTwo256::hash_of(&"unknown_hash".as_bytes().to_vec());
@@ -437,7 +455,7 @@ fn it_fails_to_acknowledges_unknown_file() {
 }
 
 #[test]
-fn it_fails_to_acknowledges_already_acknowledged_file() {
+fn it_fails_to_acknowledge_already_acknowledged_file() {
     new_test_ext().execute_with(|| {
         let file = create_loc_with_file_from_requester();
         assert_ok!(LogionLoc::acknowledge_file(RuntimeOrigin::signed(LOC_OWNER1), LOC_ID, file.hash.clone()));
@@ -446,10 +464,28 @@ fn it_fails_to_acknowledges_already_acknowledged_file() {
 }
 
 #[test]
-fn it_fails_to_acknowledges_file_when_unauthorized_caller() {
+fn it_fails_to_acknowledge_file_when_unauthorized_caller() {
     new_test_ext().execute_with(|| {
         let file = create_loc_with_file_from_requester();
         assert_err!(LogionLoc::acknowledge_file(RuntimeOrigin::signed(UNAUTHORIZED_CALLER), LOC_ID, file.hash.clone()), BadOrigin);
+    });
+}
+
+#[test]
+fn it_fails_to_acknowledge_file_when_loc_closed() {
+    new_test_ext().execute_with(|| {
+        let file = create_loc_with_file_from_requester();
+        assert_ok!(LogionLoc::close(RuntimeOrigin::signed(LOC_OWNER1), LOC_ID));
+        assert_err!(LogionLoc::acknowledge_file(RuntimeOrigin::signed(LOC_OWNER1), LOC_ID, file.hash.clone()), Error::<Test>::CannotMutate);
+    });
+}
+
+#[test]
+fn it_fails_to_acknowledge_file_when_loc_voided() {
+    new_test_ext().execute_with(|| {
+        let file = create_loc_with_file_from_requester();
+        assert_ok!(LogionLoc::make_void(RuntimeOrigin::signed(LOC_OWNER1), LOC_ID));
+        assert_err!(LogionLoc::acknowledge_file(RuntimeOrigin::signed(LOC_OWNER1), LOC_ID, file.hash.clone()), Error::<Test>::CannotMutateVoid);
     });
 }
 

--- a/pallet-logion-loc/src/weights.rs
+++ b/pallet-logion-loc/src/weights.rs
@@ -56,6 +56,7 @@ pub trait WeightInfo {
     fn create_other_identity_loc() -> Weight;
     fn sponsor() -> Weight;
     fn acknowledge_metadata() -> Weight;
+    fn acknowledge_file() -> Weight;
 }
 
 /// Weights for pallet_logion_loc using the Substrate node and recommended hardware.
@@ -157,6 +158,12 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
             .saturating_add(T::DbWeight::get().reads(1))
             .saturating_add(T::DbWeight::get().writes(1))
     }
+
+    fn acknowledge_file() -> Weight {
+        Weight::from_parts(11_979_000, 0)
+            .saturating_add(T::DbWeight::get().reads(1))
+            .saturating_add(T::DbWeight::get().writes(1))
+    }
 }
 
 // For backwards compatibility and tests
@@ -252,6 +259,11 @@ impl WeightInfo for () {
             .saturating_add(RocksDbWeight::get().writes(1))
     }
     fn acknowledge_metadata() -> Weight {
+        Weight::from_parts(11_979_000, 0)
+            .saturating_add(RocksDbWeight::get().reads(1))
+            .saturating_add(RocksDbWeight::get().writes(1))
+    }
+    fn acknowledge_file() -> Weight {
         Weight::from_parts(11_979_000, 0)
             .saturating_add(RocksDbWeight::get().reads(1))
             .saturating_add(RocksDbWeight::get().writes(1))


### PR DESCRIPTION
* File has a new attribute: `acknowledged: bool` representing the acknowledgement by the LO (owner of the LOC).
* Contributors to one LOC (requester or issuers) may now add file. Those items are stored **NOT** `acknowledged`.
* LO may still add file - they are automatically `acknowledged`.
* LO may acknowledge each file as long as the LOC is open.
* `Unauthorized` is now also thrown when the given submitter does not match the actual caller (when the caller is not the LO).

Very similar to https://github.com/logion-network/logion-pallets/pull/22, with the following additions:
* A migration for both File et Metadata is included.
* The calls `acknowledge[Metadata|File]` fail when LOC is closed/voided.