### PR TITLE
Add region

### DIFF
--- a/pallet-lo-authority-list/src/lib.rs
+++ b/pallet-lo-authority-list/src/lib.rs
@@ -95,10 +95,7 @@ pub mod pallet {
         _,
         Blake2_128Concat,
         <T as frame_system::Config>::AccountId,
-        LegalOfficerData<
-            <T as frame_system::Config>::AccountId,
-            <T as pallet::Config>::Region,
-        >
+        LegalOfficerDataOf<T>
     >;
 
     /// The set of LO nodes.
@@ -202,7 +199,7 @@ pub mod pallet {
         pub fn add_legal_officer(
             origin: OriginFor<T>,
             legal_officer_id: T::AccountId,
-            data: LegalOfficerData<T::AccountId, T::Region>,
+            data: LegalOfficerDataOf<T>,
         ) -> DispatchResultWithPostInfo {
             T::AddOrigin::ensure_origin(origin)?;
             Self::do_add_legal_officer(
@@ -239,7 +236,7 @@ pub mod pallet {
         pub fn update_legal_officer(
             origin: OriginFor<T>,
             legal_officer_id: T::AccountId,
-            data: LegalOfficerData<T::AccountId, T::Region>,
+            data: LegalOfficerDataOf<T>,
         ) -> DispatchResultWithPostInfo {
             let who = ensure_signed_or_root(origin.clone())?;
             if who.is_some() && who.clone().unwrap() != legal_officer_id {
@@ -299,12 +296,12 @@ impl<T: Config> Pallet<T> {
     where <T::Region as FromStr>::Err: Debug
     {
         for legal_officer in legal_officers {
-            LegalOfficerSet::<T>::insert::<&T::AccountId, &LegalOfficerData<T::AccountId, T::Region>>(&(legal_officer.0), &LegalOfficerData::Host(legal_officer.1.clone()));
+            LegalOfficerSet::<T>::insert::<&T::AccountId, &LegalOfficerDataOf<T>>(&(legal_officer.0), &LegalOfficerData::Host(legal_officer.1.clone()));
             LegalOfficerNodes::<T>::set(BTreeSet::new());
         }
     }
 
-    fn try_reset_legal_officer_nodes(added_or_removed_data: &LegalOfficerData<T::AccountId, T::Region>) -> Result<(), Error<T>> {
+    fn try_reset_legal_officer_nodes(added_or_removed_data: &LegalOfficerDataOf<T>) -> Result<(), Error<T>> {
         match added_or_removed_data {
             LegalOfficerData::Host(_) => Self::reset_legal_officer_nodes(),
             _ => Ok(()),
@@ -342,7 +339,7 @@ impl<T: Config> Pallet<T> {
         false
     }
 
-    fn ensure_host_if_guest(data: &LegalOfficerData<T::AccountId, T::Region>) -> Result<(), Error<T>> {
+    fn ensure_host_if_guest(data: &LegalOfficerDataOf<T>) -> Result<(), Error<T>> {
         match &data {
             LegalOfficerData::Guest(host) => Self::ensure_host(host),
             _ => Ok(()),
@@ -363,7 +360,7 @@ impl<T: Config> Pallet<T> {
 
     fn do_add_legal_officer(
         legal_officer_id: T::AccountId,
-        data: LegalOfficerData<T::AccountId, T::Region>,
+        data: LegalOfficerDataOf<T>,
     ) -> DispatchResultWithPostInfo {
         if <LegalOfficerSet<T>>::contains_key(&legal_officer_id) {
             Err(Error::<T>::AlreadyExists)?
@@ -377,7 +374,7 @@ impl<T: Config> Pallet<T> {
         }
     }
 
-    fn get_region(data: &LegalOfficerData<T::AccountId, T::Region>) -> T::Region {
+    fn get_region(data: &LegalOfficerDataOf<T>) -> T::Region {
         match data {
             LegalOfficerData::Guest(host_account_id) => Self::get_region(&LegalOfficerSet::<T>::get(host_account_id).unwrap()),
             LegalOfficerData::Host(host_data) => host_data.region,

--- a/pallet-lo-authority-list/src/mock.rs
+++ b/pallet-lo-authority-list/src/mock.rs
@@ -1,10 +1,11 @@
-use crate as pallet_lo_authority_list;
+use crate::{self as pallet_lo_authority_list, HostData, HostDataOf};
 use sp_core::hash::H256;
-use frame_support::parameter_types;
+use frame_support::{parameter_types, codec::{Encode, Decode}};
 use sp_runtime::{
     traits::{BlakeTwo256, IdentityLookup}, testing::Header,
 };
 use frame_system::{self as system, EnsureRoot};
+use scale_info::TypeInfo;
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
@@ -52,10 +53,47 @@ impl system::Config for Test {
     type MaxConsumers = frame_support::traits::ConstU32<16>;
 }
 
+#[derive(Encode, Decode, Clone, PartialEq, Eq, Debug, TypeInfo, Copy)]
+pub enum Region {
+    Europe,
+    Other,
+}
+
+impl core::str::FromStr for Region {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Europe" => Ok(Region::Europe),
+            "Other" => Ok(Region::Other),
+            _ => Err(()),
+        }
+    }
+}
+
+impl Default for Region {
+
+    fn default() -> Self {
+        Self::Europe
+    }
+}
+
+impl Default for HostDataOf<Test> {
+
+    fn default() -> Self {
+        return HostData {
+            node_id: None,
+            base_url: None,
+            region: Region::Europe,
+        }
+    }
+}
+
 impl pallet_lo_authority_list::Config for Test {
     type AddOrigin = EnsureRoot<u64>;
     type RemoveOrigin = EnsureRoot<u64>;
     type UpdateOrigin = EnsureRoot<u64>;
+    type Region = Region;
     type RuntimeEvent = RuntimeEvent;
 }
 


### PR DESCRIPTION
* Host legal officers get a region
* Region type is provided by runtime
* In order to be able to include the region in JSON chainspec files, the type must have the `FromStr` trait implemented
* The region of a legal officer cannot be changed, be it directly (for hosts) or indirectly (for guests, the region of the new host must be same as the region of previous host).

logion-network/logion-internal#914