### PR TITLE
Upgrade to polkadot-v0.9.42

### DIFF
--- a/logion-shared/Cargo.toml
+++ b/logion-shared/Cargo.toml
@@ -15,10 +15,10 @@ targets = ['x86_64-unknown-linux-gnu']
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.2.1", default-features = false, features = ["derive", "max-encoded-len"] }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.41" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.41" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.42" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.42" }
 scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
-sp-std = { git = "https://github.com/paritytech/substrate.git", default-features = false, branch = "polkadot-v0.9.41" }
+sp-std = { git = "https://github.com/paritytech/substrate.git", default-features = false, branch = "polkadot-v0.9.42" }
 
 [features]
 default = ['std']

--- a/pallet-block-reward/Cargo.toml
+++ b/pallet-block-reward/Cargo.toml
@@ -15,22 +15,22 @@ targets = ['x86_64-unknown-linux-gnu']
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "max-encoded-len"] }
-frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.41" }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.41" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.41" }
+frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.42" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.42" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.42" }
 log = { version = "0.4.14", default-features = false }
 logion-shared = { path = "../logion-shared", default-features = false }
 scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
 serde = { version = "1.0.137", optional = true, features = ["derive"] }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.41" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.41" }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.41" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.42" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.42" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.42" }
 
 [dev-dependencies]
 bs58 = "0.4.0"
-pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.41" }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.41" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.41" }
+pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.42" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.42" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.42" }
 
 [features]
 default = ['std']

--- a/pallet-block-reward/src/mock.rs
+++ b/pallet-block-reward/src/mock.rs
@@ -63,19 +63,26 @@ impl frame_system::Config for Test {
 }
 
 parameter_types! {
-    pub const MaxLocks: u32 = 4;
+    pub const MaxLocks: u32 = 2;
+    pub const MaxReserves: u32 = 2;
     pub const ExistentialDeposit: Balance = 2;
+    pub const MaxFreezes: u32 = 2;
+    pub const MaxHolds: u32 = 2;
 }
 
 impl pallet_balances::Config for Test {
     type MaxLocks = MaxLocks;
-    type MaxReserves = ();
+    type MaxReserves = MaxReserves;
     type ReserveIdentifier = [u8; 8];
     type Balance = Balance;
     type RuntimeEvent = RuntimeEvent;
     type DustRemoval = ();
     type ExistentialDeposit = ExistentialDeposit;
     type AccountStore = System;
+    type HoldIdentifier = [u8; 8];
+    type FreezeIdentifier = [u8; 8];
+    type MaxFreezes = MaxFreezes;
+    type MaxHolds = MaxHolds;
     type WeightInfo = ();
 }
 

--- a/pallet-lo-authority-list/Cargo.toml
+++ b/pallet-lo-authority-list/Cargo.toml
@@ -15,20 +15,20 @@ targets = ['x86_64-unknown-linux-gnu']
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "max-encoded-len"] }
-frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.41" }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.41" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.41" }
+frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.42" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.42" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.42" }
 log = { version = "0.4.14", default-features = false }
 logion-shared = { path = "../logion-shared", default-features = false }
 scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
 serde = { version = "1.0.137", optional = true, features = ["derive"] }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.41" }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.41" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.42" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.42" }
 
 [dev-dependencies]
 bs58 = "0.4.0"
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.41" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.41" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.42" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.42" }
 
 [features]
 default = ['std']

--- a/pallet-lo-authority-list/src/lib.rs
+++ b/pallet-lo-authority-list/src/lib.rs
@@ -56,6 +56,8 @@ pub struct HostData<Region> {
 
 pub type HostDataOf<T> = HostData<<T as Config>::Region>;
 
+pub mod weights;
+
 #[frame_support::pallet]
 pub mod pallet {
     use frame_system::pallet_prelude::*;
@@ -64,6 +66,7 @@ pub mod pallet {
         pallet_prelude::*,
     };
     use super::*;
+    pub use crate::weights::WeightInfo;
 
     #[pallet::config]
     pub trait Config: frame_system::Config {
@@ -82,6 +85,9 @@ pub mod pallet {
 
         /// The overarching event type.
         type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
+
+        /// Weight information for extrinsics in this pallet.
+        type WeightInfo: WeightInfo;
     }
 
     #[pallet::pallet]
@@ -195,7 +201,7 @@ pub mod pallet {
 
         /// Adds a new LO to the list
         #[pallet::call_index(0)]
-        #[pallet::weight(0)]
+        #[pallet::weight(T::WeightInfo::add_legal_officer())]
         pub fn add_legal_officer(
             origin: OriginFor<T>,
             legal_officer_id: T::AccountId,
@@ -210,7 +216,7 @@ pub mod pallet {
 
         /// Removes a LO from the list
         #[pallet::call_index(1)]
-        #[pallet::weight(0)]
+        #[pallet::weight(T::WeightInfo::remove_legal_officer())]
         pub fn remove_legal_officer(
             origin: OriginFor<T>,
             legal_officer_id: T::AccountId,
@@ -232,7 +238,7 @@ pub mod pallet {
 
         /// Updates an existing LO's data
         #[pallet::call_index(2)]
-        #[pallet::weight(0)]
+        #[pallet::weight(T::WeightInfo::update_legal_officer())]
         pub fn update_legal_officer(
             origin: OriginFor<T>,
             legal_officer_id: T::AccountId,

--- a/pallet-lo-authority-list/src/mock.rs
+++ b/pallet-lo-authority-list/src/mock.rs
@@ -95,6 +95,7 @@ impl pallet_lo_authority_list::Config for Test {
     type UpdateOrigin = EnsureRoot<u64>;
     type Region = Region;
     type RuntimeEvent = RuntimeEvent;
+    type WeightInfo = ();
 }
 
 // Build genesis storage according to the mock runtime.

--- a/pallet-lo-authority-list/src/weights.rs
+++ b/pallet-lo-authority-list/src/weights.rs
@@ -1,0 +1,53 @@
+#![cfg_attr(rustfmt, rustfmt_skip)]
+#![allow(unused_parens)]
+#![allow(unused_imports)]
+
+use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
+use sp_std::marker::PhantomData;
+
+/// Weight functions needed for pallet_logion_loc.
+pub trait WeightInfo {
+    fn add_legal_officer() -> Weight;
+    fn remove_legal_officer() -> Weight;
+    fn update_legal_officer() -> Weight;
+}
+
+/// Weights for pallet_logion_loc using the Substrate node and recommended hardware.
+pub struct SubstrateWeight<T>(PhantomData<T>);
+
+impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
+    fn add_legal_officer() -> Weight {
+        Weight::from_parts(29_862_000, 0)
+            .saturating_add(T::DbWeight::get().reads(1))
+            .saturating_add(T::DbWeight::get().writes(1))
+    }
+    fn remove_legal_officer() -> Weight {
+        Weight::from_parts(20_945_000, 0)
+            .saturating_add(T::DbWeight::get().reads(1))
+            .saturating_add(T::DbWeight::get().writes(1))
+    }
+    fn update_legal_officer() -> Weight {
+        Weight::from_parts(26_316_000, 0)
+            .saturating_add(T::DbWeight::get().reads(1))
+            .saturating_add(T::DbWeight::get().writes(1))
+    }
+}
+
+// For backwards compatibility and tests
+impl WeightInfo for () {
+    fn add_legal_officer() -> Weight {
+        Weight::from_parts(29_862_000, 0)
+            .saturating_add(RocksDbWeight::get().reads(3))
+            .saturating_add(RocksDbWeight::get().writes(2))
+    }
+    fn remove_legal_officer() -> Weight {
+        Weight::from_parts(20_945_000, 0)
+            .saturating_add(RocksDbWeight::get().reads(2))
+            .saturating_add(RocksDbWeight::get().writes(1))
+    }
+    fn update_legal_officer() -> Weight {
+        Weight::from_parts(26_316_000, 0)
+            .saturating_add(RocksDbWeight::get().reads(3))
+            .saturating_add(RocksDbWeight::get().writes(2))
+    }
+}

--- a/pallet-logion-loc/Cargo.toml
+++ b/pallet-logion-loc/Cargo.toml
@@ -15,21 +15,21 @@ targets = ['x86_64-unknown-linux-gnu']
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.2.1", default-features = false, features = ["derive", "max-encoded-len"] }
-frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.41" }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.41" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.41" }
+frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.42" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.42" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.42" }
 log = { version = "0.4.14", default-features = false }
 logion-shared = { path = "../logion-shared", default-features = false }
 scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.41" }
-sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.41" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.41" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.42" }
+sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.42" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.42" }
 
 [dev-dependencies]
 serde = { version = "1.0.137", features = ["derive"] }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.41" }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.41" }
-pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.41" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.42" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.42" }
+pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.42" }
 
 [features]
 default = ['std']

--- a/pallet-logion-loc/src/mock.rs
+++ b/pallet-logion-loc/src/mock.rs
@@ -60,7 +60,10 @@ impl system::Config for Test {
 
 parameter_types! {
     pub const MaxLocks: u32 = 4;
+    pub const MaxReserves: u32 = 2;
     pub const ExistentialDeposit: Balance = 2;
+    pub const MaxFreezes: u32 = 2;
+    pub const MaxHolds: u32 = 2;
 }
 
 impl pallet_balances::Config for Test {
@@ -72,6 +75,10 @@ impl pallet_balances::Config for Test {
     type DustRemoval = ();
     type ExistentialDeposit = ExistentialDeposit;
     type AccountStore = System;
+    type HoldIdentifier = [u8; 8];
+    type FreezeIdentifier = [u8; 8];
+    type MaxFreezes = MaxFreezes;
+	type MaxHolds = MaxHolds;
     type WeightInfo = ();
 }
 

--- a/pallet-logion-loc/src/tests.rs
+++ b/pallet-logion-loc/src/tests.rs
@@ -363,7 +363,7 @@ fn expected_file(file: &FileParams<H256, AccountId, EthereumAddress>, acknowledg
 }
 
 fn set_balance(account_id: AccountId, amount: Balance) {
-    assert_ok!(Balances::set_balance(RuntimeOrigin::root(), account_id, amount, 0));
+    assert_ok!(Balances::force_set_balance(RuntimeOrigin::root(), account_id, amount));
 }
 
 fn check_storage_fees(num_of_files: u32, tot_size: &u32, payer: AccountId) {

--- a/pallet-logion-vault/Cargo.toml
+++ b/pallet-logion-vault/Cargo.toml
@@ -14,19 +14,19 @@ targets = ['x86_64-unknown-linux-gnu']
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.2.1", default-features = false, features = ["derive", "max-encoded-len"] }
-frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.41" }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.41" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.41" }
+frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.42" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.42" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.42" }
 logion-shared = { path = "../logion-shared", default-features = false }
-pallet-multisig = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.41" }
+pallet-multisig = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.42" }
 scale-info = { version = "2.2.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.145", features = ["derive"] }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.41" }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.41" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.42" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.42" }
 
 [dev-dependencies]
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.41" }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.41" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.42" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.42" }
 
 [features]
 default = ['std']

--- a/pallet-logion-vote/Cargo.toml
+++ b/pallet-logion-vote/Cargo.toml
@@ -14,19 +14,19 @@ targets = ['x86_64-unknown-linux-gnu']
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.2.1", default-features = false, features = ["derive", "max-encoded-len"] }
-frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.41" }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.41" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.41" }
+frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.42" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.42" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.42" }
 log = { version = "0.4.14", default-features = false }
 logion-shared = { path = "../logion-shared", default-features = false }
 scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.41" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.42" }
 
 [dev-dependencies]
 serde = { version = "1.0.137", features = ["derive"] }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.41" }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.41" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.41" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.42" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.42" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.42" }
 
 [features]
 default = ['std']

--- a/pallet-logion-vote/src/lib.rs
+++ b/pallet-logion-vote/src/lib.rs
@@ -35,6 +35,8 @@ pub type VoteId = u64;
 pub type VoteClosed = bool;
 pub type VoteApproved = bool;
 
+pub mod weights;
+
 #[frame_support::pallet]
 pub mod pallet {
     use codec::HasCompact;
@@ -47,6 +49,7 @@ pub mod pallet {
     use logion_shared::{IsLegalOfficer, LegalOfficerCreation, LocQuery, LocValidity};
     use crate::BallotStatus::{NotVoted, VotedNo, VotedYes};
     use super::*;
+    pub use crate::weights::WeightInfo;
 
     #[pallet::config]
     pub trait Config: frame_system::Config {
@@ -67,6 +70,9 @@ pub mod pallet {
 
         /// Creation of a guest LO
         type LegalOfficerCreation: LegalOfficerCreation<Self::AccountId>;
+
+        /// Weight information for extrinsics in this pallet.
+        type WeightInfo: WeightInfo;
     }
 
     #[pallet::pallet]
@@ -108,7 +114,7 @@ pub mod pallet {
     impl<T: Config> Pallet<T> {
         /// Creates a new Vote.
         #[pallet::call_index(0)]
-        #[pallet::weight(0)]
+        #[pallet::weight(T::WeightInfo::create_vote_for_all_legal_officers())]
         pub fn create_vote_for_all_legal_officers(
             origin: OriginFor<T>,
             #[pallet::compact] loc_id: T::LocId,
@@ -135,7 +141,7 @@ pub mod pallet {
 
         /// Vote.
         #[pallet::call_index(1)]
-        #[pallet::weight(0)]
+        #[pallet::weight(T::WeightInfo::vote())]
         pub fn vote(
             origin: OriginFor<T>,
             #[pallet::compact] vote_id: VoteId,

--- a/pallet-logion-vote/src/mock.rs
+++ b/pallet-logion-vote/src/mock.rs
@@ -122,6 +122,7 @@ impl pallet_logion_vote::Config for Test {
     type LocValidity = LocValidityMock;
     type LocQuery = LocQueryMock;
     type LegalOfficerCreation = LegalOfficerCreationMock;
+    type WeightInfo = ();
 }
 
 // Build genesis storage according to the mock runtime.

--- a/pallet-logion-vote/src/weights.rs
+++ b/pallet-logion-vote/src/weights.rs
@@ -1,0 +1,42 @@
+#![cfg_attr(rustfmt, rustfmt_skip)]
+#![allow(unused_parens)]
+#![allow(unused_imports)]
+
+use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
+use sp_std::marker::PhantomData;
+
+/// Weight functions needed for pallet_logion_loc.
+pub trait WeightInfo {
+    fn create_vote_for_all_legal_officers() -> Weight;
+    fn vote() -> Weight;
+}
+
+/// Weights for pallet_logion_loc using the Substrate node and recommended hardware.
+pub struct SubstrateWeight<T>(PhantomData<T>);
+
+impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
+    fn create_vote_for_all_legal_officers() -> Weight {
+        Weight::from_parts(29_862_000, 0)
+            .saturating_add(T::DbWeight::get().reads(1))
+            .saturating_add(T::DbWeight::get().writes(1))
+    }
+    fn vote() -> Weight {
+        Weight::from_parts(20_945_000, 0)
+            .saturating_add(T::DbWeight::get().reads(1))
+            .saturating_add(T::DbWeight::get().writes(1))
+    }
+}
+
+// For backwards compatibility and tests
+impl WeightInfo for () {
+    fn create_vote_for_all_legal_officers() -> Weight {
+        Weight::from_parts(29_862_000, 0)
+            .saturating_add(RocksDbWeight::get().reads(1))
+            .saturating_add(RocksDbWeight::get().writes(1))
+    }
+    fn vote() -> Weight {
+        Weight::from_parts(20_945_000, 0)
+            .saturating_add(RocksDbWeight::get().reads(1))
+            .saturating_add(RocksDbWeight::get().writes(1))
+    }
+}

--- a/pallet-verified-recovery/Cargo.toml
+++ b/pallet-verified-recovery/Cargo.toml
@@ -15,18 +15,18 @@ targets = ['x86_64-unknown-linux-gnu']
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.2.1", default-features = false, features = ["derive", "max-encoded-len"] }
-frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.41" }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.41" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.41" }
+frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.42" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.42" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.42" }
 logion-shared = { path = "../logion-shared", default-features = false }
 scale-info = { version = "2.2.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.145", features = ["derive"] }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.41" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.42" }
 
 [dev-dependencies]
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.41" }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.41" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.41" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.42" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.42" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.42" }
 
 [features]
 default = ['std']


### PR DESCRIPTION
* Upgrades dependencies
* Adds dummy weights to pallet-lo-authority-list (fixes warning about constant weights being deprecated)

logion-network/logion-internal#888