### PR TITLE
Log migrated data after upgrade with try-runtime

### DIFF
--- a/pallet-logion-loc/src/lib.rs
+++ b/pallet-logion-loc/src/lib.rs
@@ -540,6 +540,24 @@ pub mod pallet {
         fn integrity_test() {
             assert!(T::FileStorageFeeDistributionKey::get().is_valid());
         }
+
+        #[cfg(feature = "try-runtime")]
+        fn post_upgrade(_state: Vec<u8>) -> Result<(), &'static str> {
+            LocMap::<T>::iter().for_each(|entry| {
+                let loc_id = entry.0;
+                let loc = entry.1;
+                loc.metadata.iter().for_each(|metadata| {
+                    log::info!("LOC {:?} metadata {:?} value {:?}", loc_id, metadata.name, metadata.value);
+                });
+                loc.files.iter().for_each(|file| {
+                    log::info!("LOC {:?} file {:?} nature {:?}", loc_id, file.hash, file.nature);
+                });
+                loc.links.iter().for_each(|link| {
+                    log::info!("LOC {:?} link {:?} nature {:?}", loc_id, link.id, link.nature);
+                });
+            });
+            Ok(())
+        }
     }
 
     #[derive(Encode, Decode, Eq, PartialEq, Debug, TypeInfo)]


### PR DESCRIPTION
* Automatically testing the migration would require to explicitly keep a copy of the storage before the migration, then compare the migrated data to the initial dataset
* Given current Substrate toolset, this is rather complex and would imply to keep a copy of previous state in-memory
* Other approach: migrated data are logged in a way that enables the manual validation of migrated data
* Manual test procedure:
  * Try the runtime
  * Choose several LOC elements in the logs and go to Polkadot.js to visualize the non-hashed value
  * Use `echo -n "..." | sha256sum` to generate the hash and compare it with what you see in the logs

logion-network/logion-internal#928