### PR TITLE
Add value fees

### DIFF
--- a/logion-shared/src/tests.rs
+++ b/logion-shared/src/tests.rs
@@ -7,6 +7,7 @@ fn distribution_key_with_only_reserve_is_valid() {
         reserve_percent: Percent::from_percent(100),
         stakers_percent: Percent::from_percent(0),
         collators_percent: Percent::from_percent(0),
+        treasury_percent: Percent::from_percent(0),
     };
     assert!(key.is_valid());
 }
@@ -17,6 +18,7 @@ fn distribution_key_with_only_stakers_is_valid() {
         reserve_percent: Percent::from_percent(0),
         stakers_percent: Percent::from_percent(100),
         collators_percent: Percent::from_percent(0),
+        treasury_percent: Percent::from_percent(0),
     };
     assert!(key.is_valid());
 }
@@ -27,6 +29,7 @@ fn distribution_key_with_only_collators_is_valid() {
         reserve_percent: Percent::from_percent(0),
         stakers_percent: Percent::from_percent(0),
         collators_percent: Percent::from_percent(100),
+        treasury_percent: Percent::from_percent(0),
     };
     assert!(key.is_valid());
 }
@@ -37,6 +40,7 @@ fn distribution_key_is_valid() {
         reserve_percent: Percent::from_percent(50),
         stakers_percent: Percent::from_percent(30),
         collators_percent: Percent::from_percent(20),
+        treasury_percent: Percent::from_percent(0),
     };
     assert!(key.is_valid());
 }
@@ -47,6 +51,7 @@ fn distribution_key_invalid_lower_than_hundred() {
         reserve_percent: Percent::from_percent(49),
         stakers_percent: Percent::from_percent(30),
         collators_percent: Percent::from_percent(20),
+        treasury_percent: Percent::from_percent(0),
     };
     assert!(!key.is_valid());
 }
@@ -57,6 +62,7 @@ fn distribution_key_invalid_greater_than_hundred() {
         reserve_percent: Percent::from_percent(51),
         stakers_percent: Percent::from_percent(30),
         collators_percent: Percent::from_percent(20),
+        treasury_percent: Percent::from_percent(0),
     };
     assert!(!key.is_valid());
 }

--- a/pallet-block-reward/src/mock.rs
+++ b/pallet-block-reward/src/mock.rs
@@ -90,6 +90,7 @@ impl pallet_balances::Config for Test {
 pub const RESERVE_ACCOUNT: AccountId = 2;
 pub const COLLATORS_ACCOUNT: AccountId = 3;
 pub const STAKERS_ACCOUNT: AccountId = 4;
+pub const TREASURY_ACCOUNT: AccountId = 5;
 
 // Type used as beneficiary payout handle
 pub struct RewardDistributorImpl();
@@ -107,6 +108,10 @@ for RewardDistributorImpl
     fn payout_stakers(reward: NegativeImbalanceOf<Test>) {
         Balances::resolve_creating(&STAKERS_ACCOUNT, reward);
     }
+
+    fn payout_treasury(reward: NegativeImbalanceOf<Test>) {
+        Balances::resolve_creating(&TREASURY_ACCOUNT, reward);
+    }
 }
 
 pub const BLOCK_REWARD: Balance = 10_000_000_000_000_000_000; // 10 LGNT
@@ -117,6 +122,7 @@ parameter_types! {
         stakers_percent: Percent::from_percent(50),
         collators_percent: Percent::from_percent(30),
         reserve_percent: Percent::from_percent(20),
+        treasury_percent: Percent::from_percent(0),
     };
 }
 

--- a/pallet-logion-loc/Cargo.toml
+++ b/pallet-logion-loc/Cargo.toml
@@ -23,6 +23,7 @@ logion-shared = { path = "../logion-shared", default-features = false }
 scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
 sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.43" }
 sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.43" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.43" }
 sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.43" }
 
 [dev-dependencies]
@@ -43,6 +44,7 @@ std = [
 	'sp-std/std',
 	'pallet-balances/std',
 	"sp-api/std",
+	"sp-core/std",
 	"sp-runtime/std",
 ]
 runtime-benchmarks = [

--- a/pallet-logion-loc/src/migrations.rs
+++ b/pallet-logion-loc/src/migrations.rs
@@ -7,6 +7,69 @@ use frame_support::traits::OnRuntimeUpgrade;
 use crate::{Config, PalletStorageVersion, pallet::StorageVersion};
 use super::*;
 
+pub mod v18 {
+    use super::*;
+    use crate::*;
+
+    #[derive(Encode, Decode, Default, Clone, PartialEq, Eq, Debug, TypeInfo)]
+    pub struct LegalOfficerCaseV17<AccountId, Hash, LocId, BlockNumber, EthereumAddress, SponsorshipId> {
+        owner: AccountId,
+        requester: Requester<AccountId, LocId, EthereumAddress>,
+        metadata: Vec<MetadataItem<AccountId, EthereumAddress, Hash>>,
+        files: Vec<File<Hash, AccountId, EthereumAddress>>,
+        closed: bool,
+        loc_type: LocType,
+        links: Vec<LocLink<LocId, Hash>>,
+        void_info: Option<LocVoidInfo<LocId>>,
+        replacer_of: Option<LocId>,
+        collection_last_block_submission: Option<BlockNumber>,
+        collection_max_size: Option<CollectionSize>,
+        collection_can_upload: bool,
+        seal: Option<Hash>,
+        sponsorship_id: Option<SponsorshipId>,
+    }
+
+    pub type LegalOfficerCaseV17Of<T> = LegalOfficerCaseV17<
+        <T as frame_system::Config>::AccountId,
+        <T as pallet::Config>::Hash,
+        <T as pallet::Config>::LocId,
+        <T as frame_system::Config>::BlockNumber,
+        <T as pallet::Config>::EthereumAddress,
+        <T as pallet::Config>::SponsorshipId,
+    >;
+
+    pub struct AddValueFee<T>(sp_std::marker::PhantomData<T>);
+    impl<T: Config> OnRuntimeUpgrade for AddValueFee<T> {
+        fn on_runtime_upgrade() -> Weight {
+            super::do_storage_upgrade::<T, _>(
+                StorageVersion::V17HashItemRecordPublicData,
+                StorageVersion::V18AddValueFee,
+                "AddValueFee",
+                || {
+                    LocMap::<T>::translate_values(|loc: LegalOfficerCaseV17Of<T>| {
+                        Some(LegalOfficerCase {
+                            owner: loc.owner,
+                            requester: loc.requester,
+                            metadata: loc.metadata,
+                            files: loc.files,
+                            closed: loc.closed,
+                            loc_type: loc.loc_type,
+                            links: loc.links,
+                            void_info: loc.void_info,
+                            replacer_of: loc.replacer_of,
+                            collection_last_block_submission: loc.collection_last_block_submission,
+                            collection_max_size: loc.collection_max_size,
+                            collection_can_upload: loc.collection_can_upload,
+                            seal: loc.seal,
+                            sponsorship_id: loc.sponsorship_id,
+                            value_fee: BalanceOf::<T>::from(0u32),
+                        })
+                    });
+                }
+            )
+        }
+    }
+}
 
 pub mod v17 {
     use super::*;

--- a/pallet-logion-loc/src/mock.rs
+++ b/pallet-logion-loc/src/mock.rs
@@ -144,6 +144,10 @@ for RewardDistributor
     fn payout_stakers(reward: NegativeImbalanceOf<Test>) {
         Balances::resolve_creating(&STAKERS_ACCOUNT, reward);
     }
+
+    fn payout_treasury(reward: NegativeImbalanceOf<Test>) {
+        Balances::resolve_creating(&TREASURY_ACCOUNT_ID, reward);
+    }
 }
 
 parameter_types! {
@@ -153,6 +157,7 @@ parameter_types! {
         stakers_percent: Percent::from_percent(50),
         collators_percent: Percent::from_percent(30),
         reserve_percent: Percent::from_percent(20),
+        treasury_percent: Percent::from_percent(0),
     };
     pub const ExchangeRate: Balance = 200_000_000_000_000_000; // 1 euro cent = 0.2 LGNT;
     pub const TreasuryAccountId: u64 = TREASURY_ACCOUNT_ID;
@@ -161,6 +166,13 @@ parameter_types! {
         stakers_percent: Percent::from_percent(50),
         collators_percent: Percent::from_percent(30),
         reserve_percent: Percent::from_percent(20),
+        treasury_percent: Percent::from_percent(0),
+    };
+    pub const ValueFeeDistributionKey: DistributionKey = DistributionKey {
+        stakers_percent: Percent::from_percent(0),
+        collators_percent: Percent::from_percent(0),
+        reserve_percent: Percent::from_percent(0),
+        treasury_percent: Percent::from_percent(100),
     };
 }
 
@@ -221,6 +233,7 @@ impl pallet_loc::Config for Test {
     type CertificateFee = CertificateFee;
     type CertificateFeeDistributionKey = CertificateFeeDistributionKey;
     type TokenIssuance = TokenIssuance;
+    type ValueFeeDistributionKey = ValueFeeDistributionKey;
 }
 
 // Build genesis storage according to the mock runtime.


### PR DESCRIPTION
* Treasury was added to the distribution key in order to re-use reward distributor for value fees.
* The treasury part is zero for all fees except for value fees where it is 100%.
* A migration is required in order to add value fees to existing LOCs (set to 0 by default).

logion-network/logion-internal#958