### PR TITLE
Add possibility for verified issuer to acknowledge item.

### DIFF
--- a/pallet-logion-loc/src/lib.rs
+++ b/pallet-logion-loc/src/lib.rs
@@ -581,7 +581,20 @@ pub mod pallet {
 
         #[cfg(feature = "try-runtime")]
         fn post_upgrade(_state: Vec<u8>) -> Result<(), sp_runtime::DispatchError> {
+
             assert_eq!(PalletStorageVersion::<T>::get(), StorageVersion::default());
+
+            LocMap::<T>::iter().for_each(|entry| {
+                let loc_id = entry.0;
+                let loc = entry.1;
+                loc.metadata.iter().for_each(|metadata| {
+                    log::info!("LOC {:?} metadata {:?} acknowledged_by_owner {:?} acknowledged_by_verified_issuer {:?}", loc_id, metadata.name, metadata.acknowledged_by_owner, metadata.acknowledged_by_verified_issuer);
+                });
+                loc.files.iter().for_each(|file| {
+                    log::info!("LOC {:?} file {:?} acknowledged_by_owner {:?} acknowledged_by_verified_issuer {:?}", loc_id, file.hash, file.acknowledged_by_owner, file.acknowledged_by_verified_issuer);
+                });
+            });
+
             Ok(())
         }
     }

--- a/pallet-logion-loc/src/lib.rs
+++ b/pallet-logion-loc/src/lib.rs
@@ -271,6 +271,7 @@ pub mod pallet {
     use crate::SupportedAccountId::Polkadot;
     use super::*;
     pub use crate::weights::WeightInfo;
+    pub use crate::migrations::v19::AcknowledgeItemsByIssuer;
 
     #[pallet::config]
     pub trait Config: frame_system::Config {
@@ -589,9 +590,13 @@ pub mod pallet {
                 let loc = entry.1;
                 loc.metadata.iter().for_each(|metadata| {
                     log::info!("LOC {:?} metadata {:?} acknowledged_by_owner {:?} acknowledged_by_verified_issuer {:?}", loc_id, metadata.name, metadata.acknowledged_by_owner, metadata.acknowledged_by_verified_issuer);
+                    let acknowledged_by_verified_issuer = AcknowledgeItemsByIssuer::<T>::acknowledged_by_verified_issuer(&loc.owner, &loc.requester, &metadata.submitter);
+                    assert_eq!(metadata.acknowledged_by_verified_issuer, acknowledged_by_verified_issuer);
                 });
                 loc.files.iter().for_each(|file| {
                     log::info!("LOC {:?} file {:?} acknowledged_by_owner {:?} acknowledged_by_verified_issuer {:?}", loc_id, file.hash, file.acknowledged_by_owner, file.acknowledged_by_verified_issuer);
+                    let acknowledged_by_verified_issuer = AcknowledgeItemsByIssuer::<T>::acknowledged_by_verified_issuer(&loc.owner, &loc.requester, &file.submitter);
+                    assert_eq!(file.acknowledged_by_verified_issuer, acknowledged_by_verified_issuer);
                 });
             });
 

--- a/pallet-logion-loc/src/migrations.rs
+++ b/pallet-logion-loc/src/migrations.rs
@@ -65,9 +65,9 @@ pub mod v19 {
         BalanceOf<T>,
     >;
 
-    pub struct HashLocPublicData<T>(sp_std::marker::PhantomData<T>);
+    pub struct AcknowledgeItemsByIssuer<T>(sp_std::marker::PhantomData<T>);
 
-    impl<T: Config> HashLocPublicData<T> {
+    impl<T: Config> AcknowledgeItemsByIssuer<T> {
 
         fn acknowledged_by_verified_issuer(loc: &LegalOfficerCaseV18Of<T>, submitter: &SupportedAccountId<T::AccountId, T::EthereumAddress>) -> bool {
             // Any polkadot submitter different from owner or requester, will be assumed to be verified issuer.
@@ -87,13 +87,13 @@ pub mod v19 {
             }
         }
     }
-    impl<T: Config> OnRuntimeUpgrade for HashLocPublicData<T> {
+    impl<T: Config> OnRuntimeUpgrade for AcknowledgeItemsByIssuer<T> {
 
         fn on_runtime_upgrade() -> Weight {
             super::do_storage_upgrade::<T, _>(
                 StorageVersion::V18AddValueFee,
                 StorageVersion::V19AcknowledgeItemsByIssuer,
-                "HashLocPublicData",
+                "AcknowledgeItemsByIssuer",
                 || {
                     LocMap::<T>::translate_values(|loc: LegalOfficerCaseV18Of<T>| {
                         let files: Vec<File<<T as pallet::Config>::Hash, <T as frame_system::Config>::AccountId, T::EthereumAddress>> = loc.files
@@ -103,8 +103,8 @@ pub mod v19 {
                                 nature: file.nature,
                                 submitter: file.submitter.clone(),
                                 size: file.size,
-                                acknowledged: file.acknowledged,
-                                acknowledged_by_verified_issuer: Self::acknowledged_by_verified_issuer(&loc,&file.submitter),
+                                acknowledged_by_owner: file.acknowledged,
+                                acknowledged_by_verified_issuer: Self::acknowledged_by_verified_issuer(&loc, &file.submitter),
                             })
                             .collect();
                         let metadata: Vec<MetadataItem<<T as frame_system::Config>::AccountId, T::EthereumAddress, <T as pallet::Config>::Hash>> = loc.metadata
@@ -113,8 +113,8 @@ pub mod v19 {
                                 name: item.name,
                                 value: item.value,
                                 submitter: item.submitter.clone(),
-                                acknowledged: item.acknowledged,
-                                acknowledged_by_verified_issuer: Self::acknowledged_by_verified_issuer(&loc,&item.submitter),
+                                acknowledged_by_owner: item.acknowledged,
+                                acknowledged_by_verified_issuer: Self::acknowledged_by_verified_issuer(&loc, &item.submitter),
                             })
                             .collect();
                         Some(LegalOfficerCaseOf::<T> {

--- a/pallet-logion-loc/src/migrations.rs
+++ b/pallet-logion-loc/src/migrations.rs
@@ -69,14 +69,14 @@ pub mod v19 {
 
     impl<T: Config> AcknowledgeItemsByIssuer<T> {
 
-        fn acknowledged_by_verified_issuer(loc: &LegalOfficerCaseV18Of<T>, submitter: &SupportedAccountId<T::AccountId, T::EthereumAddress>) -> bool {
+        pub fn acknowledged_by_verified_issuer(owner: &T::AccountId, requester: &RequesterOf<T>, submitter: &SupportedAccountId<T::AccountId, T::EthereumAddress>) -> bool {
             // Any polkadot submitter different from owner or requester, will be assumed to be verified issuer.
             match submitter {
                 SupportedAccountId::Polkadot(polkadot_submitter) => {
-                    if *polkadot_submitter == loc.owner {
+                    if *polkadot_submitter == owner.clone() {
                         false
                     } else {
-                        let submitted_by_requester = match &loc.requester {
+                        let submitted_by_requester = match requester {
                             Account(polkadot_requester) => polkadot_requester == polkadot_submitter,
                             _ => false
                         };
@@ -104,7 +104,7 @@ pub mod v19 {
                                 submitter: file.submitter.clone(),
                                 size: file.size,
                                 acknowledged_by_owner: file.acknowledged,
-                                acknowledged_by_verified_issuer: Self::acknowledged_by_verified_issuer(&loc, &file.submitter),
+                                acknowledged_by_verified_issuer: Self::acknowledged_by_verified_issuer(&loc.owner, &loc.requester, &file.submitter),
                             })
                             .collect();
                         let metadata: Vec<MetadataItem<<T as frame_system::Config>::AccountId, T::EthereumAddress, <T as pallet::Config>::Hash>> = loc.metadata
@@ -114,7 +114,7 @@ pub mod v19 {
                                 value: item.value,
                                 submitter: item.submitter.clone(),
                                 acknowledged_by_owner: item.acknowledged,
-                                acknowledged_by_verified_issuer: Self::acknowledged_by_verified_issuer(&loc, &item.submitter),
+                                acknowledged_by_verified_issuer: Self::acknowledged_by_verified_issuer(&loc.owner, &loc.requester, &item.submitter),
                             })
                             .collect();
                         Some(LegalOfficerCaseOf::<T> {


### PR DESCRIPTION
* Each item may now be acknowledged by the verified issuer who submitted it, after publication by the requester.
* Thus a new attribute `acknowledged_by_verified_issuer` is added to metadata items and files.
* `acknowledged` is renamed to  `acknowledged_by_owner`.
* A migration is provided.
* Publication (addition) of metadata/files is now stricter - only owner and requester are authorised.

logion-network/logion-internal#968