### PR TITLE
Fee Distribution major update

### DIFF
--- a/logion-shared/src/lib.rs
+++ b/logion-shared/src/lib.rs
@@ -170,16 +170,8 @@ pub trait RewardDistributor<I: Imbalance<B>, B: Balance, AccountId: Clone> {
 
 }
 
-pub type EuroCent = u32;
-
 #[derive(Encode, Decode, Clone, PartialEq, Eq, Debug, TypeInfo, Copy)]
 pub enum Beneficiary<AccountId> {
     Other,
     LegalOfficer(AccountId),
-}
-
-pub trait LegalFee<LocType> {
-
-    fn get_default_legal_fee(loc_type: LocType) -> EuroCent;
-
 }

--- a/logion-shared/src/lib.rs
+++ b/logion-shared/src/lib.rs
@@ -178,10 +178,8 @@ pub enum Beneficiary<AccountId> {
     LegalOfficer(AccountId),
 }
 
-pub trait LegalFee<I: Imbalance<B>, B: Balance, LocType, AccountId> {
+pub trait LegalFee<LocType> {
 
     fn get_default_legal_fee(loc_type: LocType) -> EuroCent;
 
-    /// Determine, distribute to, and return the beneficiary of Legal fee.
-    fn distribute(amount: I, loc_type: LocType, loc_owner: AccountId) -> Beneficiary<AccountId>;
 }

--- a/logion-shared/src/lib.rs
+++ b/logion-shared/src/lib.rs
@@ -92,10 +92,9 @@ pub trait LegalOfficerCreation<AccountId> {
 
 #[derive(Debug, PartialEq)]
 pub struct DistributionKey {
-    pub reserve_percent: Percent,
-    pub stakers_percent: Percent,
+    pub community_treasury_percent: Percent,
     pub collators_percent: Percent,
-    pub treasury_percent: Percent,
+    pub logion_treasury_percent: Percent,
     pub loc_owner_percent: Percent,
 }
 
@@ -104,10 +103,9 @@ impl DistributionKey {
     pub fn is_valid(&self) -> bool {
         let mut should_become_zero = Self::into_signed(Percent::one());
 
-        should_become_zero = should_become_zero - Self::into_signed(self.reserve_percent);
-        should_become_zero = should_become_zero - Self::into_signed(self.stakers_percent);
+        should_become_zero = should_become_zero - Self::into_signed(self.community_treasury_percent);
         should_become_zero = should_become_zero - Self::into_signed(self.collators_percent);
-        should_become_zero = should_become_zero - Self::into_signed(self.treasury_percent);
+        should_become_zero = should_become_zero - Self::into_signed(self.logion_treasury_percent);
         should_become_zero = should_become_zero - Self::into_signed(self.loc_owner_percent);
 
         should_become_zero == 0
@@ -126,11 +124,9 @@ pub trait RewardDistributor<I: Imbalance<B>, B: Balance, AccountId: Clone> {
 
     fn payout_collators(reward: I);
 
-    fn payout_reserve(reward: I);
+    fn payout_community_treasury(reward: I);
 
-    fn payout_stakers(reward: I);
-
-    fn payout_treasury(reward: I);
+    fn payout_logion_treasury(reward: I);
 
     fn payout_to(reward: I, account: &AccountId);
 
@@ -145,20 +141,17 @@ pub trait RewardDistributor<I: Imbalance<B>, B: Balance, AccountId: Clone> {
     fn _distribute(amount: I, distribution_key: DistributionKey, loc_owner: Option<&AccountId>) -> (Beneficiary<AccountId>, B)  {
         let amount_balance = amount.peek();
 
-        let stakers_part = distribution_key.stakers_percent * amount_balance;
         let collators_part = distribution_key.collators_percent * amount_balance;
-        let treasury_part = distribution_key.treasury_percent * amount_balance;
+        let logion_treasury_part = distribution_key.logion_treasury_percent * amount_balance;
         let loc_owner_part = distribution_key.loc_owner_percent * amount_balance;
 
-        let (stakers_imbalance, remainder1) = amount.split(stakers_part);
-        let (collators_imbalance, remainder2) = remainder1.split(collators_part);
-        let (loc_owner_imbalance, remainder3) = remainder2.split(loc_owner_part);
-        let (treasury_imbalance, reserve_imbalance) = remainder3.split(treasury_part);
+        let (collators_imbalance, remainder1) = amount.split(collators_part);
+        let (loc_owner_imbalance, remainder2) = remainder1.split(loc_owner_part);
+        let (logion_treasury_imbalance, community_treasury_imbalance) = remainder2.split(logion_treasury_part);
 
-        Self::payout_stakers(stakers_imbalance);
-        Self::payout_reserve(reserve_imbalance);
+        Self::payout_community_treasury(community_treasury_imbalance);
         Self::payout_collators(collators_imbalance);
-        Self::payout_treasury(treasury_imbalance);
+        Self::payout_logion_treasury(logion_treasury_imbalance);
         match loc_owner {
             Some(account) => {
                 if distribution_key.loc_owner_percent != Percent::zero() {

--- a/logion-shared/src/tests.rs
+++ b/logion-shared/src/tests.rs
@@ -2,25 +2,11 @@ use frame_support::sp_runtime::Percent;
 use crate::DistributionKey;
 
 #[test]
-fn distribution_key_with_only_reserve_is_valid() {
+fn distribution_key_with_only_community_treasury_is_valid() {
     let key = DistributionKey {
-        reserve_percent: Percent::from_percent(100),
-        stakers_percent: Percent::from_percent(0),
+        community_treasury_percent: Percent::from_percent(100),
         collators_percent: Percent::from_percent(0),
-        treasury_percent: Percent::from_percent(0),
-        loc_owner_percent: Percent::from_percent(0),
-    };
-    assert!(key.is_valid());
-    assert!(key.is_valid_without_loc_owner());
-}
-
-#[test]
-fn distribution_key_with_only_stakers_is_valid() {
-    let key = DistributionKey {
-        reserve_percent: Percent::from_percent(0),
-        stakers_percent: Percent::from_percent(100),
-        collators_percent: Percent::from_percent(0),
-        treasury_percent: Percent::from_percent(0),
+        logion_treasury_percent: Percent::from_percent(0),
         loc_owner_percent: Percent::from_percent(0),
     };
     assert!(key.is_valid());
@@ -30,10 +16,9 @@ fn distribution_key_with_only_stakers_is_valid() {
 #[test]
 fn distribution_key_with_only_collators_is_valid() {
     let key = DistributionKey {
-        reserve_percent: Percent::from_percent(0),
-        stakers_percent: Percent::from_percent(0),
+        community_treasury_percent: Percent::from_percent(0),
         collators_percent: Percent::from_percent(100),
-        treasury_percent: Percent::from_percent(0),
+        logion_treasury_percent: Percent::from_percent(0),
         loc_owner_percent: Percent::from_percent(0),
     };
     assert!(key.is_valid());
@@ -42,11 +27,10 @@ fn distribution_key_with_only_collators_is_valid() {
 #[test]
 fn distribution_key_is_valid_only_with_loc_owner() {
     let key = DistributionKey {
-        reserve_percent: Percent::from_percent(40),
-        stakers_percent: Percent::from_percent(30),
+        community_treasury_percent: Percent::from_percent(40),
         collators_percent: Percent::from_percent(20),
-        treasury_percent: Percent::from_percent(6),
-        loc_owner_percent: Percent::from_percent(4),
+        logion_treasury_percent: Percent::from_percent(30),
+        loc_owner_percent: Percent::from_percent(10),
     };
     assert!(key.is_valid());
     assert!(!key.is_valid_without_loc_owner());
@@ -55,10 +39,9 @@ fn distribution_key_is_valid_only_with_loc_owner() {
 #[test]
 fn distribution_key_invalid_lower_than_hundred() {
     let key = DistributionKey {
-        reserve_percent: Percent::from_percent(49),
-        stakers_percent: Percent::from_percent(30),
+        community_treasury_percent: Percent::from_percent(49),
         collators_percent: Percent::from_percent(20),
-        treasury_percent: Percent::from_percent(0),
+        logion_treasury_percent: Percent::from_percent(0),
         loc_owner_percent: Percent::from_percent(0),
     };
     assert!(!key.is_valid());
@@ -68,10 +51,9 @@ fn distribution_key_invalid_lower_than_hundred() {
 #[test]
 fn distribution_key_invalid_greater_than_hundred() {
     let key = DistributionKey {
-        reserve_percent: Percent::from_percent(51),
-        stakers_percent: Percent::from_percent(30),
+        community_treasury_percent: Percent::from_percent(51),
         collators_percent: Percent::from_percent(20),
-        treasury_percent: Percent::from_percent(0),
+        logion_treasury_percent: Percent::from_percent(0),
         loc_owner_percent: Percent::from_percent(0),
     };
     assert!(!key.is_valid());

--- a/pallet-block-reward/src/mock.rs
+++ b/pallet-block-reward/src/mock.rs
@@ -82,30 +82,25 @@ impl pallet_balances::Config for Test {
 }
 
 // Fake accounts used to simulate reward beneficiaries balances
-pub const RESERVE_ACCOUNT: AccountId = 2;
+pub const COMMUNITY_TREASURY_ACCOUNT: AccountId = 2;
 pub const COLLATORS_ACCOUNT: AccountId = 3;
-pub const STAKERS_ACCOUNT: AccountId = 4;
-pub const TREASURY_ACCOUNT: AccountId = 5;
+pub const LOGION_TREASURY_ACCOUNT: AccountId = 5;
 
 // Type used as beneficiary payout handle
 pub struct RewardDistributorImpl();
 impl RewardDistributor<NegativeImbalanceOf<Test>, Balance, AccountId>
 for RewardDistributorImpl
 {
-    fn payout_reserve(reward: NegativeImbalanceOf<Test>) {
-        Balances::resolve_creating(&RESERVE_ACCOUNT, reward);
+    fn payout_community_treasury(reward: NegativeImbalanceOf<Test>) {
+        Balances::resolve_creating(&COMMUNITY_TREASURY_ACCOUNT, reward);
     }
 
     fn payout_collators(reward: NegativeImbalanceOf<Test>) {
         Balances::resolve_creating(&COLLATORS_ACCOUNT, reward);
     }
 
-    fn payout_stakers(reward: NegativeImbalanceOf<Test>) {
-        Balances::resolve_creating(&STAKERS_ACCOUNT, reward);
-    }
-
-    fn payout_treasury(reward: NegativeImbalanceOf<Test>) {
-        Balances::resolve_creating(&TREASURY_ACCOUNT, reward);
+    fn payout_logion_treasury(reward: NegativeImbalanceOf<Test>) {
+        Balances::resolve_creating(&LOGION_TREASURY_ACCOUNT, reward);
     }
 
     fn payout_to(_reward: NegativeImbalanceOf<Test>, _account: &AccountId) {
@@ -118,10 +113,9 @@ pub const BLOCK_REWARD: Balance = 10_000_000_000_000_000_000; // 10 LGNT
 parameter_types! {
     pub const RewardAmount: Balance = BLOCK_REWARD;
     pub const RewardDistributionKey: DistributionKey = DistributionKey {
-        stakers_percent: Percent::from_percent(50),
-        collators_percent: Percent::from_percent(30),
-        reserve_percent: Percent::from_percent(20),
-        treasury_percent: Percent::from_percent(0),
+        collators_percent: Percent::from_percent(0),
+        community_treasury_percent: Percent::from_percent(100),
+        logion_treasury_percent: Percent::from_percent(0),
         loc_owner_percent: Percent::from_percent(0),
     };
 }

--- a/pallet-block-reward/src/tests.rs
+++ b/pallet-block-reward/src/tests.rs
@@ -22,10 +22,7 @@ pub fn inflation_as_expected() {
 pub fn reward_distributed_as_expected() {
     new_test_ext().execute_with(|| {
         BlockReward::on_finalize(0);
-
-        assert_eq!(get_free_balance(RESERVE_ACCOUNT), 2_000_000_000_000_000_000);
-        assert_eq!(get_free_balance(STAKERS_ACCOUNT), 5_000_000_000_000_000_000);
-        assert_eq!(get_free_balance(COLLATORS_ACCOUNT), 3_000_000_000_000_000_000);
+        assert_eq!(get_free_balance(COMMUNITY_TREASURY_ACCOUNT), 10_000_000_000_000_000_000);
     })
 }
 

--- a/pallet-logion-loc/src/fees.rs
+++ b/pallet-logion-loc/src/fees.rs
@@ -12,10 +12,9 @@ pub struct BalancesSnapshot {
     pub legal_officer_account: AccountId,
     pub payer: Balance,
     pub payer_reserved: Balance,
-    pub treasury: Balance,
-    pub stakers: Balance,
+    pub logion_treasury: Balance,
     pub collators: Balance,
-    pub reserve: Balance,
+    pub community_treasury: Balance,
     pub legal_officer: Balance,
 }
 impl BalancesSnapshot {
@@ -26,10 +25,9 @@ impl BalancesSnapshot {
             legal_officer_account,
             payer: Self::get_free_balance(payer_account),
             payer_reserved: Self::get_reserved_balance(payer_account),
-            treasury: Self::get_free_balance(TREASURY_ACCOUNT_ID),
-            stakers: Self::get_free_balance(STAKERS_ACCOUNT),
+            logion_treasury: Self::get_free_balance(LOGION_TREASURY_ACCOUNT_ID),
             collators: Self::get_free_balance(COLLATORS_ACCOUNT),
-            reserve: Self::get_free_balance(RESERVE_ACCOUNT),
+            community_treasury: Self::get_free_balance(COMMUNITY_TREASURY_ACCOUNT),
             legal_officer: Self::get_free_balance(legal_officer_account),
         }
     }
@@ -46,10 +44,9 @@ impl BalancesSnapshot {
         BalancesDelta {
             payer: previous.payer.saturating_sub(Self::get_free_balance(previous.payer_account)),
             payer_reserved: previous.payer_reserved.saturating_sub(Self::get_reserved_balance(previous.payer_account)),
-            treasury: Self::get_free_balance(TREASURY_ACCOUNT_ID).saturating_sub(previous.treasury),
-            stakers: Self::get_free_balance(STAKERS_ACCOUNT).saturating_sub(previous.stakers),
+            logion_treasury: Self::get_free_balance(LOGION_TREASURY_ACCOUNT_ID).saturating_sub(previous.logion_treasury),
             collators: Self::get_free_balance(COLLATORS_ACCOUNT).saturating_sub(previous.collators),
-            reserve: Self::get_free_balance(RESERVE_ACCOUNT).saturating_sub(previous.reserve),
+            community_treasury: Self::get_free_balance(COMMUNITY_TREASURY_ACCOUNT).saturating_sub(previous.community_treasury),
             legal_officer: Self::get_free_balance(previous.legal_officer_account).saturating_sub(previous.legal_officer),
         }
     }
@@ -59,23 +56,21 @@ impl BalancesSnapshot {
 pub struct BalancesDelta {
     /// Debited amount or 0 if credited
     payer: u128,
-    /// Debited amount from reserve or 0 if credited
+    /// Debited amount from community_treasury or 0 if credited
     payer_reserved: u128,
     /// Credited amount or 0 if debited
-    treasury: u128,
-    /// Credited amount or 0 if debited
-    stakers: u128,
+    logion_treasury: u128,
     /// Credited amount or 0 if debited
     collators: u128,
     /// Credited amount or 0 if debited
-    reserve: u128,
+    community_treasury: u128,
     /// Credited amount or 0 if debited
     legal_officer: u128,
 }
 impl BalancesDelta {
 
     pub fn total_credited(&self) -> u128 {
-        self.treasury + self.stakers + self.collators + self.reserve + self.legal_officer
+        self.logion_treasury + self.collators + self.community_treasury + self.legal_officer
     }
 
     pub fn total_debited(&self) -> u128 {

--- a/pallet-logion-loc/src/lib.rs
+++ b/pallet-logion-loc/src/lib.rs
@@ -826,6 +826,7 @@ pub mod pallet {
 
                 assert_eq!(loc.collection_item_fee, 0_u32.into());
                 assert_eq!(loc.tokens_record_fee, 0_u32.into());
+                assert!(loc.legal_fee.ge(Balance::zero()));
             });
 
             Ok(())

--- a/pallet-logion-loc/src/lib.rs
+++ b/pallet-logion-loc/src/lib.rs
@@ -1343,7 +1343,7 @@ pub mod pallet {
                     }
                     let fee_payer = match collection_loc.requester {
                         Account(requester_account) => requester_account,
-                        _ => collection_loc.owner.clone()
+                        _ => panic!("Requester cannot pay the fees")
                     };
 
                     let tot_size = files.iter()

--- a/pallet-logion-loc/src/mock.rs
+++ b/pallet-logion-loc/src/mock.rs
@@ -88,7 +88,7 @@ pub const LOGION_IDENTITY_LOC_ID: u32 = 4;
 pub const ISSUER_ID1: u64 = 5;
 pub const ISSUER_ID2: u64 = 6;
 pub const SPONSOR_ID: u64 = 7;
-pub const TREASURY_ACCOUNT_ID: u64 = 8;
+pub const LOGION_TREASURY_ACCOUNT_ID: u64 = 8;
 pub const UNAUTHORIZED_CALLER: u64 = 9;
 
 pub struct LoAuthorityListMock;
@@ -119,29 +119,24 @@ parameter_types! {
 }
 
 // Fake accounts used to simulate reward beneficiaries balances
-pub const RESERVE_ACCOUNT: AccountId = 20;
+pub const COMMUNITY_TREASURY_ACCOUNT: AccountId = 20;
 pub const COLLATORS_ACCOUNT: AccountId = 21;
-pub const STAKERS_ACCOUNT: AccountId = 22;
 
 // Type used as beneficiary payout handle
 pub struct RewardDistributor;
 impl logion_shared::RewardDistributor<NegativeImbalanceOf<Test>, Balance, AccountId>
 for RewardDistributor
 {
-    fn payout_reserve(reward: NegativeImbalanceOf<Test>) {
-        Balances::resolve_creating(&RESERVE_ACCOUNT, reward);
+    fn payout_community_treasury(reward: NegativeImbalanceOf<Test>) {
+        Balances::resolve_creating(&COMMUNITY_TREASURY_ACCOUNT, reward);
     }
 
     fn payout_collators(reward: NegativeImbalanceOf<Test>) {
         Balances::resolve_creating(&COLLATORS_ACCOUNT, reward);
     }
 
-    fn payout_stakers(reward: NegativeImbalanceOf<Test>) {
-        Balances::resolve_creating(&STAKERS_ACCOUNT, reward);
-    }
-
-    fn payout_treasury(reward: NegativeImbalanceOf<Test>) {
-        Balances::resolve_creating(&TREASURY_ACCOUNT_ID, reward);
+    fn payout_logion_treasury(reward: NegativeImbalanceOf<Test>) {
+        Balances::resolve_creating(&LOGION_TREASURY_ACCOUNT_ID, reward);
     }
 
     fn payout_to(reward: NegativeImbalanceOf<Test>, account: &AccountId) {
@@ -152,35 +147,31 @@ for RewardDistributor
 parameter_types! {
     pub const FileStorageByteFee: u32 = 10u32;
     pub const FileStorageEntryFee: u32 = 100u32;
-    pub const RewardDistributionKey: DistributionKey = DistributionKey {
-        stakers_percent: Percent::from_percent(50),
-        collators_percent: Percent::from_percent(30),
-        reserve_percent: Percent::from_percent(20),
-        treasury_percent: Percent::from_percent(0),
+    pub const FileStorageFeeDistributionKey: DistributionKey = DistributionKey {
+        collators_percent: Percent::from_percent(80),
+        community_treasury_percent: Percent::from_percent(20),
+        logion_treasury_percent: Percent::from_percent(0),
         loc_owner_percent: Percent::from_percent(0),
     };
     pub const ExchangeRate: Balance = 200_000_000_000_000_000; // 1 euro cent = 0.2 LGNT;
-    pub const TreasuryAccountId: u64 = TREASURY_ACCOUNT_ID;
+    pub const LogionTreasuryAccountId: u64 = LOGION_TREASURY_ACCOUNT_ID;
     pub const CertificateFee: u64 = 4_000_000_000_000_000; // 0.004 LGNT
     pub const CertificateFeeDistributionKey: DistributionKey = DistributionKey {
-        stakers_percent: Percent::from_percent(50),
-        collators_percent: Percent::from_percent(30),
-        reserve_percent: Percent::from_percent(20),
-        treasury_percent: Percent::from_percent(0),
+        collators_percent: Percent::from_percent(20),
+        community_treasury_percent: Percent::from_percent(80),
+        logion_treasury_percent: Percent::from_percent(0),
         loc_owner_percent: Percent::from_percent(0),
     };
     pub const ValueFeeDistributionKey: DistributionKey = DistributionKey {
-        stakers_percent: Percent::from_percent(0),
         collators_percent: Percent::from_percent(0),
-        reserve_percent: Percent::from_percent(0),
-        treasury_percent: Percent::from_percent(100),
+        community_treasury_percent: Percent::from_percent(0),
+        logion_treasury_percent: Percent::from_percent(100),
         loc_owner_percent: Percent::from_percent(0),
     };
     pub const RecurentFeeDistributionKey: DistributionKey = DistributionKey {
-        stakers_percent: Percent::from_percent(0),
         collators_percent: Percent::from_percent(0),
-        reserve_percent: Percent::from_percent(0),
-        treasury_percent: Percent::from_percent(95),
+        community_treasury_percent: Percent::from_percent(0),
+        logion_treasury_percent: Percent::from_percent(95),
         loc_owner_percent: Percent::from_percent(5),
     };
 }
@@ -197,7 +188,7 @@ impl LegalFee<NegativeImbalanceOf<Test>, Balance, LocType, AccountId> for LegalF
     fn distribute(amount: NegativeImbalanceOf<Test>, loc_type: LocType, loc_owner: AccountId) -> Beneficiary<AccountId> {
 
         let (beneficiary, target) = match loc_type {
-            LocType::Identity => (Beneficiary::Other, TREASURY_ACCOUNT_ID),
+            LocType::Identity => (Beneficiary::Other, LOGION_TREASURY_ACCOUNT_ID),
             _ => (Beneficiary::LegalOfficer(loc_owner), loc_owner),
         };
         Balances::resolve_creating(&target, amount);
@@ -234,7 +225,7 @@ impl pallet_loc::Config for Test {
     type FileStorageByteFee = FileStorageByteFee;
     type FileStorageEntryFee = FileStorageEntryFee;
     type RewardDistributor = RewardDistributor;
-    type FileStorageFeeDistributionKey = RewardDistributionKey;
+    type FileStorageFeeDistributionKey = FileStorageFeeDistributionKey;
     type EthereumAddress = EthereumAddress;
     type SponsorshipId = SponsorshipId;
     type LegalFee = LegalFeeImpl;

--- a/pallet-logion-loc/src/mock.rs
+++ b/pallet-logion-loc/src/mock.rs
@@ -1,5 +1,5 @@
-use crate::{self as pallet_loc, LocType, NegativeImbalanceOf, RequesterOf, Hasher};
-use logion_shared::{DistributionKey, EuroCent, IsLegalOfficer, LegalFee};
+use crate::{self as pallet_loc, NegativeImbalanceOf, RequesterOf, Hasher};
+use logion_shared::{DistributionKey, IsLegalOfficer};
 use sp_core::hash::H256;
 use frame_support::{construct_runtime, parameter_types, traits::{EnsureOrigin, Currency}};
 use sp_io::hashing::sha2_256;
@@ -153,7 +153,6 @@ parameter_types! {
         logion_treasury_percent: Percent::from_percent(0),
         loc_owner_percent: Percent::from_percent(0),
     };
-    pub const ExchangeRate: Balance = 200_000_000_000_000_000; // 1 euro cent = 0.2 LGNT;
     pub const LogionTreasuryAccountId: u64 = LOGION_TREASURY_ACCOUNT_ID;
     pub const CertificateFee: u64 = 4_000_000_000_000_000; // 0.004 LGNT
     pub const CertificateFeeDistributionKey: DistributionKey = DistributionKey {
@@ -188,16 +187,6 @@ parameter_types! {
     };
 }
 
-pub struct LegalFeeImpl;
-impl LegalFee<LocType> for LegalFeeImpl {
-    fn get_default_legal_fee(loc_type: LocType) -> EuroCent {
-        match loc_type {
-            LocType::Identity => 8_00, // 8.00 euros
-            _ => 100_00, // 100.00 euros
-        }
-    }
-}
-
 pub struct SHA256;
 impl Hasher<H256> for SHA256 {
 
@@ -230,8 +219,6 @@ impl pallet_loc::Config for Test {
     type FileStorageFeeDistributionKey = FileStorageFeeDistributionKey;
     type EthereumAddress = EthereumAddress;
     type SponsorshipId = SponsorshipId;
-    type LegalFee = LegalFeeImpl;
-    type ExchangeRate = ExchangeRate;
     type CertificateFee = CertificateFee;
     type CertificateFeeDistributionKey = CertificateFeeDistributionKey;
     type TokenIssuance = TokenIssuance;

--- a/pallet-logion-loc/src/runtime_api.rs
+++ b/pallet-logion-loc/src/runtime_api.rs
@@ -5,7 +5,6 @@
 use sp_api;
 use codec::Codec;
 use sp_runtime::traits::MaybeDisplay;
-use crate::LocType;
 
 sp_api::decl_runtime_apis! {
 
@@ -14,9 +13,6 @@ sp_api::decl_runtime_apis! {
     {
         /// Query expected fees for submitting given files
         fn query_file_storage_fee(num_of_entries: u32, tot_size: u32) -> Balance;
-
-        /// Query expected legal fees for opening a LOC with given type
-        fn query_legal_fee(loc_type: LocType) -> Balance;
 
         /// Query expected item legal fees for adding an item with given type
         fn query_certificate_fee(token_issuance: TokenIssuance) -> Balance;

--- a/pallet-logion-loc/src/tests.rs
+++ b/pallet-logion-loc/src/tests.rs
@@ -68,7 +68,7 @@ fn setup_default_balances() {
     set_balance(LOC_OWNER2, INITIAL_BALANCE);
     set_balance(ISSUER_ID1, INITIAL_BALANCE);
     set_balance(ISSUER_ID2, INITIAL_BALANCE);
-    set_balance(TREASURY_ACCOUNT_ID, INITIAL_BALANCE);
+    set_balance(LOGION_TREASURY_ACCOUNT_ID, INITIAL_BALANCE);
 }
 
 fn set_balance(account_id: AccountId, amount: Balance) {
@@ -2501,7 +2501,7 @@ fn it_captures_value_fees() {
 }
 
 #[test]
-fn it_frees_value_fees_reserve_on_void() {
+fn it_frees_value_fees_community_treasury_on_void() {
     new_test_ext().execute_with(|| {
         setup_default_balances();
         let value_fee = 100;
@@ -2514,7 +2514,7 @@ fn it_frees_value_fees_reserve_on_void() {
 }
 
 #[test]
-fn it_does_not_free_value_fees_reserve_on_void_closed() {
+fn it_does_not_free_value_fees_community_treasury_on_void_closed() {
     new_test_ext().execute_with(|| {
         setup_default_balances();
         let value_fee = 100;


### PR DESCRIPTION
* Split current `treasury` in `logion_treasury` and `community_treasury`.
* Use `RewardDistributor` and `DistributionKey` for legal fees.
* Remove default Legal Fee management from pallet/node.
* Remove `stakers` and `reserve` from `DistributionKey`.

logion-network/logion-internal#1049