### PR TITLE
Collators reward.

### DIFF
--- a/logion-shared/src/lib.rs
+++ b/logion-shared/src/lib.rs
@@ -122,7 +122,22 @@ impl DistributionKey {
 
 pub trait RewardDistributor<I: Imbalance<B>, B: Balance, AccountId: Clone> {
 
-    fn payout_collators(reward: I);
+    fn payout_collators(reward: I) {
+
+        if reward.peek() != B::zero() {
+            let collators = Self::get_collators();
+            let mut remainder = reward;
+            let size = collators.len();
+            for i in 0..size {
+                let collator = &collators[i];
+                let (amount, new_remainder) = remainder.ration(1, (size - i - 1) as u32);
+                Self::payout_to(amount, collator);
+                remainder = new_remainder;
+            }
+        }
+    }
+
+    fn get_collators() -> Vec<AccountId>;
 
     fn payout_community_treasury(reward: I);
 

--- a/logion-shared/src/lib.rs
+++ b/logion-shared/src/lib.rs
@@ -130,7 +130,8 @@ pub trait RewardDistributor<I: Imbalance<B>, B: Balance, AccountId: Clone> {
             let size = collators.len();
             for i in 0..size {
                 let collator = &collators[i];
-                let (amount, new_remainder) = remainder.ration(1, (size - i - 1) as u32);
+                let num_of_remaining_collators = (size - i - 1) as u32;
+                let (amount, new_remainder) = remainder.ration(1, num_of_remaining_collators);
                 Self::payout_to(amount, collator);
                 remainder = new_remainder;
             }

--- a/logion-shared/src/tests.rs
+++ b/logion-shared/src/tests.rs
@@ -1,5 +1,5 @@
 use frame_support::sp_runtime::Percent;
-use crate::DistributionKey;
+use crate::{DistributionKey, RewardDistributor};
 
 #[test]
 fn distribution_key_with_only_community_treasury_is_valid() {

--- a/logion-shared/src/tests.rs
+++ b/logion-shared/src/tests.rs
@@ -1,5 +1,5 @@
 use frame_support::sp_runtime::Percent;
-use crate::{DistributionKey, RewardDistributor};
+use crate::DistributionKey;
 
 #[test]
 fn distribution_key_with_only_community_treasury_is_valid() {

--- a/pallet-block-reward/src/mock.rs
+++ b/pallet-block-reward/src/mock.rs
@@ -83,8 +83,12 @@ impl pallet_balances::Config for Test {
 
 // Fake accounts used to simulate reward beneficiaries balances
 pub const COMMUNITY_TREASURY_ACCOUNT: AccountId = 2;
-pub const COLLATORS_ACCOUNT: AccountId = 3;
+pub const COLLATORS_ACCOUNT_1: AccountId = 3;
+pub const COLLATORS_ACCOUNT_2: AccountId = 4;
 pub const LOGION_TREASURY_ACCOUNT: AccountId = 5;
+pub const COLLATORS_ACCOUNT_3: AccountId = 6;
+pub const COLLATORS_ACCOUNT_4: AccountId = 7;
+pub const COLLATORS_ACCOUNT_5: AccountId = 8;
 
 // Type used as beneficiary payout handle
 pub struct RewardDistributorImpl();
@@ -95,16 +99,16 @@ for RewardDistributorImpl
         Balances::resolve_creating(&COMMUNITY_TREASURY_ACCOUNT, reward);
     }
 
-    fn payout_collators(reward: NegativeImbalanceOf<Test>) {
-        Balances::resolve_creating(&COLLATORS_ACCOUNT, reward);
+    fn get_collators() -> Vec<AccountId> {
+        vec![COLLATORS_ACCOUNT_1, COLLATORS_ACCOUNT_2, COLLATORS_ACCOUNT_3, COLLATORS_ACCOUNT_4, COLLATORS_ACCOUNT_5]
     }
 
     fn payout_logion_treasury(reward: NegativeImbalanceOf<Test>) {
         Balances::resolve_creating(&LOGION_TREASURY_ACCOUNT, reward);
     }
 
-    fn payout_to(_reward: NegativeImbalanceOf<Test>, _account: &AccountId) {
-        panic!("Impossible to reward a given account with inflation")
+    fn payout_to(reward: NegativeImbalanceOf<Test>, account: &AccountId) {
+        Balances::resolve_creating(account, reward);
     }
 }
 
@@ -113,9 +117,9 @@ pub const BLOCK_REWARD: Balance = 10_000_000_000_000_000_000; // 10 LGNT
 parameter_types! {
     pub const RewardAmount: Balance = BLOCK_REWARD;
     pub const RewardDistributionKey: DistributionKey = DistributionKey {
-        collators_percent: Percent::from_percent(0),
-        community_treasury_percent: Percent::from_percent(100),
-        logion_treasury_percent: Percent::from_percent(0),
+        collators_percent: Percent::from_percent(35),
+        community_treasury_percent: Percent::from_percent(30),
+        logion_treasury_percent: Percent::from_percent(35),
         loc_owner_percent: Percent::from_percent(0),
     };
 }

--- a/pallet-block-reward/src/tests.rs
+++ b/pallet-block-reward/src/tests.rs
@@ -22,7 +22,13 @@ pub fn inflation_as_expected() {
 pub fn reward_distributed_as_expected() {
     new_test_ext().execute_with(|| {
         BlockReward::on_finalize(0);
-        assert_eq!(get_free_balance(COMMUNITY_TREASURY_ACCOUNT), 10_000_000_000_000_000_000);
+        assert_eq!(get_free_balance(COLLATORS_ACCOUNT_1), 700_000_000_000_000_000);
+        assert_eq!(get_free_balance(COLLATORS_ACCOUNT_2), 700_000_000_000_000_000);
+        assert_eq!(get_free_balance(COLLATORS_ACCOUNT_3), 700_000_000_000_000_000);
+        assert_eq!(get_free_balance(COLLATORS_ACCOUNT_4), 700_000_000_000_000_000);
+        assert_eq!(get_free_balance(COLLATORS_ACCOUNT_5), 700_000_000_000_000_000);
+        assert_eq!(get_free_balance(COMMUNITY_TREASURY_ACCOUNT), 3_000_000_000_000_000_000);
+        assert_eq!(get_free_balance(LOGION_TREASURY_ACCOUNT), 3_500_000_000_000_000_000);
     })
 }
 

--- a/pallet-logion-loc/src/mock.rs
+++ b/pallet-logion-loc/src/mock.rs
@@ -131,8 +131,8 @@ for RewardDistributor
         Balances::resolve_creating(&COMMUNITY_TREASURY_ACCOUNT, reward);
     }
 
-    fn payout_collators(reward: NegativeImbalanceOf<Test>) {
-        Balances::resolve_creating(&COLLATORS_ACCOUNT, reward);
+    fn get_collators() -> Vec<AccountId> {
+        vec![COLLATORS_ACCOUNT]
     }
 
     fn payout_logion_treasury(reward: NegativeImbalanceOf<Test>) {


### PR DESCRIPTION
* Runtime must implement `fn get_collators() -> Vec<AccountId>`.
* For `n` collators, each of them receive `1/n` amount - but exact amount may differ at the last digit due to rounding.

___

Not included: the vec of collators should be shuffled (or similar mechanism) in order to avoid rounding always occur similarly for the same accounts.

logion-network/logion-internal#1066