### PR TITLE
Turn payout_collators into payout_legal_officers.

### DIFF
--- a/logion-shared/src/tests.rs
+++ b/logion-shared/src/tests.rs
@@ -5,7 +5,7 @@ use crate::DistributionKey;
 fn distribution_key_with_only_community_treasury_is_valid() {
     let key = DistributionKey {
         community_treasury_percent: Percent::from_percent(100),
-        collators_percent: Percent::from_percent(0),
+        legal_officers_percent: Percent::from_percent(0),
         logion_treasury_percent: Percent::from_percent(0),
         loc_owner_percent: Percent::from_percent(0),
     };
@@ -14,10 +14,10 @@ fn distribution_key_with_only_community_treasury_is_valid() {
 }
 
 #[test]
-fn distribution_key_with_only_collators_is_valid() {
+fn distribution_key_with_only_legal_officers_is_valid() {
     let key = DistributionKey {
         community_treasury_percent: Percent::from_percent(0),
-        collators_percent: Percent::from_percent(100),
+        legal_officers_percent: Percent::from_percent(100),
         logion_treasury_percent: Percent::from_percent(0),
         loc_owner_percent: Percent::from_percent(0),
     };
@@ -28,7 +28,7 @@ fn distribution_key_with_only_collators_is_valid() {
 fn distribution_key_is_valid_only_with_loc_owner() {
     let key = DistributionKey {
         community_treasury_percent: Percent::from_percent(40),
-        collators_percent: Percent::from_percent(20),
+        legal_officers_percent: Percent::from_percent(20),
         logion_treasury_percent: Percent::from_percent(30),
         loc_owner_percent: Percent::from_percent(10),
     };
@@ -40,7 +40,7 @@ fn distribution_key_is_valid_only_with_loc_owner() {
 fn distribution_key_invalid_lower_than_hundred() {
     let key = DistributionKey {
         community_treasury_percent: Percent::from_percent(49),
-        collators_percent: Percent::from_percent(20),
+        legal_officers_percent: Percent::from_percent(20),
         logion_treasury_percent: Percent::from_percent(0),
         loc_owner_percent: Percent::from_percent(0),
     };
@@ -52,7 +52,7 @@ fn distribution_key_invalid_lower_than_hundred() {
 fn distribution_key_invalid_greater_than_hundred() {
     let key = DistributionKey {
         community_treasury_percent: Percent::from_percent(51),
-        collators_percent: Percent::from_percent(20),
+        legal_officers_percent: Percent::from_percent(20),
         logion_treasury_percent: Percent::from_percent(0),
         loc_owner_percent: Percent::from_percent(0),
     };

--- a/pallet-block-reward/src/lib.rs
+++ b/pallet-block-reward/src/lib.rs
@@ -16,7 +16,7 @@ mod tests;
 
 #[frame_support::pallet]
 pub mod pallet {
-    use logion_shared::{DistributionKey, RewardDistributor};
+    use logion_shared::{DistributionKey, IsLegalOfficer, RewardDistributor};
     use super::*;
 
     #[pallet::pallet]
@@ -34,8 +34,11 @@ pub mod pallet {
         /// The currency trait.
         type Currency: Currency<Self::AccountId>;
 
+        /// Query for getting the list of legal officers
+        type IsLegalOfficer: IsLegalOfficer<Self::AccountId, Self::RuntimeOrigin>;
+
         /// Used to payout rewards
-        type RewardDistributor: RewardDistributor<NegativeImbalanceOf<Self>, BalanceOf<Self>, Self::AccountId>;
+        type RewardDistributor: RewardDistributor<NegativeImbalanceOf<Self>, BalanceOf<Self>, Self::AccountId,  Self::RuntimeOrigin, Self::IsLegalOfficer>;
 
         /// The amount of issuance for each block.
         #[pallet::constant]

--- a/pallet-block-reward/src/tests.rs
+++ b/pallet-block-reward/src/tests.rs
@@ -22,11 +22,11 @@ pub fn inflation_as_expected() {
 pub fn reward_distributed_as_expected() {
     new_test_ext().execute_with(|| {
         BlockReward::on_finalize(0);
-        assert_eq!(get_free_balance(COLLATORS_ACCOUNT_1), 700_000_000_000_000_000);
-        assert_eq!(get_free_balance(COLLATORS_ACCOUNT_2), 700_000_000_000_000_000);
-        assert_eq!(get_free_balance(COLLATORS_ACCOUNT_3), 700_000_000_000_000_000);
-        assert_eq!(get_free_balance(COLLATORS_ACCOUNT_4), 700_000_000_000_000_000);
-        assert_eq!(get_free_balance(COLLATORS_ACCOUNT_5), 700_000_000_000_000_000);
+        assert_eq!(get_free_balance(LEGAL_OFFICER_ACCOUNT_1), 700_000_000_000_000_000);
+        assert_eq!(get_free_balance(LEGAL_OFFICER_ACCOUNT_2), 700_000_000_000_000_000);
+        assert_eq!(get_free_balance(LEGAL_OFFICER_ACCOUNT_3), 700_000_000_000_000_000);
+        assert_eq!(get_free_balance(LEGAL_OFFICER_ACCOUNT_4), 700_000_000_000_000_000);
+        assert_eq!(get_free_balance(LEGAL_OFFICER_ACCOUNT_5), 700_000_000_000_000_000);
         assert_eq!(get_free_balance(COMMUNITY_TREASURY_ACCOUNT), 3_000_000_000_000_000_000);
         assert_eq!(get_free_balance(LOGION_TREASURY_ACCOUNT), 3_500_000_000_000_000_000);
     })

--- a/pallet-logion-loc/src/fees.rs
+++ b/pallet-logion-loc/src/fees.rs
@@ -1,34 +1,37 @@
-use sp_runtime::Percent;
 use logion_shared::Beneficiary;
+use sp_runtime::Percent;
 
-use crate::{
-    Config,
-    mock::*
-};
+use crate::{mock::*, Config};
 
 /// Balances of accounts involved in fees payment
 pub struct BalancesSnapshot {
     pub payer_account: AccountId,
-    pub legal_officer_account: AccountId,
     pub payer: Balance,
     pub payer_reserved: Balance,
     pub logion_treasury: Balance,
-    pub collators: Balance,
     pub community_treasury: Balance,
-    pub legal_officer: Balance,
+    pub legal_officers: Vec<(AccountId, Balance)>,
 }
 impl BalancesSnapshot {
-
-    pub fn take(payer_account: AccountId, legal_officer_account: AccountId) -> BalancesSnapshot {
+    pub fn take(
+        payer_account: AccountId,
+        legal_officer_accounts: Vec<AccountId>,
+    ) -> BalancesSnapshot {
         BalancesSnapshot {
             payer_account,
-            legal_officer_account,
             payer: Self::get_free_balance(payer_account),
             payer_reserved: Self::get_reserved_balance(payer_account),
             logion_treasury: Self::get_free_balance(LOGION_TREASURY_ACCOUNT_ID),
-            collators: Self::get_free_balance(COLLATORS_ACCOUNT),
             community_treasury: Self::get_free_balance(COMMUNITY_TREASURY_ACCOUNT),
-            legal_officer: Self::get_free_balance(legal_officer_account),
+            legal_officers: legal_officer_accounts
+                .iter()
+                .map(|legal_officer_account| {
+                    (
+                        legal_officer_account.clone(),
+                        Self::get_free_balance(legal_officer_account.clone()),
+                    )
+                })
+                .collect(),
         }
     }
 
@@ -45,9 +48,10 @@ impl BalancesSnapshot {
             payer: previous.payer.saturating_sub(Self::get_free_balance(previous.payer_account)),
             payer_reserved: previous.payer_reserved.saturating_sub(Self::get_reserved_balance(previous.payer_account)),
             logion_treasury: Self::get_free_balance(LOGION_TREASURY_ACCOUNT_ID).saturating_sub(previous.logion_treasury),
-            collators: Self::get_free_balance(COLLATORS_ACCOUNT).saturating_sub(previous.collators),
             community_treasury: Self::get_free_balance(COMMUNITY_TREASURY_ACCOUNT).saturating_sub(previous.community_treasury),
-            legal_officer: Self::get_free_balance(previous.legal_officer_account).saturating_sub(previous.legal_officer),
+            legal_officers: previous.legal_officers.iter()
+                .map(|legal_officer| Self::get_free_balance(legal_officer.0.clone()).saturating_sub(legal_officer.1.clone()))
+                .collect(),
         }
     }
 }
@@ -61,16 +65,13 @@ pub struct BalancesDelta {
     /// Credited amount or 0 if debited
     logion_treasury: u128,
     /// Credited amount or 0 if debited
-    collators: u128,
-    /// Credited amount or 0 if debited
     community_treasury: u128,
     /// Credited amount or 0 if debited
-    legal_officer: u128,
+    legal_officers: Vec<u128>,
 }
 impl BalancesDelta {
-
     pub fn total_credited(&self) -> u128 {
-        self.logion_treasury + self.collators + self.community_treasury + self.legal_officer
+        self.logion_treasury + self.community_treasury + self.legal_officers.iter().sum::<u128>()
     }
 
     pub fn total_debited(&self) -> u128 {
@@ -160,22 +161,27 @@ impl Fees {
 
     pub fn assert_balances_events(&self, previous_balances: BalancesSnapshot) {
         let expected_fees_total = self.total();
-    
-        let current_balances = BalancesSnapshot::take(previous_balances.payer_account, previous_balances.legal_officer_account);
+
+        let current_balances = BalancesSnapshot::take(
+            previous_balances.payer_account,
+            previous_balances.legal_officers.iter()
+                .map(|legal_officer| legal_officer.0.clone())
+                .collect(),
+        );
         let balances_delta = current_balances.delta_since(&previous_balances);
         let credited_fees: Balance = balances_delta.total_credited();
         assert_eq!(credited_fees, expected_fees_total);
-    
+
         let debited_fees = balances_delta.total_debited() + balances_delta.total_debited_reserve();
         assert_eq!(debited_fees, expected_fees_total);
-    
+
         if self.storage_fees > 0 {
             System::assert_has_event(RuntimeEvent::LogionLoc(crate::Event::StorageFeeWithdrawn {
                 0: previous_balances.payer_account,
                 1: self.storage_fees,
             }));
         }
-    
+
         if self.legal_fees > 0 {
             System::assert_has_event(RuntimeEvent::LogionLoc(crate::Event::LegalFeeWithdrawn {
                 0: previous_balances.payer_account,
@@ -183,11 +189,11 @@ impl Fees {
                 2: self.legal_fees,
             }));
         }
-    
+
         if self.certificate_fees > 0 {
             System::assert_has_event(RuntimeEvent::LogionLoc(crate::Event::CertificateFeeWithdrawn {
-                0: previous_balances.payer_account,
-                1: self.certificate_fees,
+                    0: previous_balances.payer_account,
+                    1: self.certificate_fees,
             }));
         }
 
@@ -198,22 +204,22 @@ impl Fees {
             }));
         }
 
-        let  percent_to_loc_owner: Percent = RecurentFeeDistributionKey::get().loc_owner_percent;
+        let percent_to_loc_owner: Percent = RecurentFeeDistributionKey::get().loc_owner_percent;
         if self.collection_item_fee > 0 {
             System::assert_has_event(RuntimeEvent::LogionLoc(crate::Event::CollectionItemFeeWithdrawn {
-                0: previous_balances.payer_account,
-                1: self.collection_item_fee,
-                2: self.fee_beneficiary.unwrap(),
-                3: percent_to_loc_owner * self.collection_item_fee,
+                    0: previous_balances.payer_account,
+                    1: self.collection_item_fee,
+                    2: self.fee_beneficiary.unwrap(),
+                    3: percent_to_loc_owner * self.collection_item_fee,
             }));
         }
 
         if self.tokens_record_fee > 0 {
             System::assert_has_event(RuntimeEvent::LogionLoc(crate::Event::TokensRecordFeeWithdrawn {
-                0: previous_balances.payer_account,
-                1: self.tokens_record_fee,
-                2: self.fee_beneficiary.unwrap(),
-                3: percent_to_loc_owner * self.tokens_record_fee,
+                    0: previous_balances.payer_account,
+                    1: self.tokens_record_fee,
+                    2: self.fee_beneficiary.unwrap(),
+                    3: percent_to_loc_owner * self.tokens_record_fee,
             }));
         }
     }

--- a/pallet-logion-loc/src/lib.rs
+++ b/pallet-logion-loc/src/lib.rs
@@ -550,7 +550,7 @@ pub mod pallet {
         type FileStorageEntryFee: Get<BalanceOf<Self>>;
 
         /// Used to payout fees
-        type RewardDistributor: RewardDistributor<NegativeImbalanceOf<Self>, BalanceOf<Self>, Self::AccountId>;
+        type RewardDistributor: RewardDistributor<NegativeImbalanceOf<Self>, BalanceOf<Self>, Self::AccountId, Self::RuntimeOrigin, Self::IsLegalOfficer>;
 
         /// Used to compute storage fees rewards
         type FileStorageFeeDistributionKey: Get<DistributionKey>;


### PR DESCRIPTION
* Wording is adapted: `Collators` are now `LegalOfficers` (with proper case).
* All legal officers balances are recorded into BalancesSnapshot in order to keep test invariant _all debited equals to all credited_ true.
* Legal officers are obtained via `IsLegalOfficer.legal_officers()` and therefore won't require any specific implementation on the node side.

logion-network/logion-internal#1066