### PR TITLE
Benchmark pallet-lo-authority-list

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+root = true
+
+[*]
+indent_style=space
+indent_size=2
+tab_width=2
+end_of_line=lf
+charset=utf-8
+trim_trailing_whitespace=true
+insert_final_newline = true
+
+[*.{rs,toml}]
+indent_style=tab
+indent_size=tab
+tab_width=4
+max_line_length=100

--- a/pallet-lo-authority-list/Cargo.toml
+++ b/pallet-lo-authority-list/Cargo.toml
@@ -14,6 +14,7 @@ keywords = ['logion']
 targets = ['x86_64-unknown-linux-gnu']
 
 [dependencies]
+bs58 = { version = "0.5.0", default-features = false, features = ["alloc"] }
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive", "max-encoded-len"] }
 frame-benchmarking = { git = "https://github.com/paritytech/polkadot-sdk", default-features = false, optional = true, tag = "polkadot-v1.3.0" }
 frame-support = { git = "https://github.com/paritytech/polkadot-sdk", default-features = false, tag = "polkadot-v1.3.0" }
@@ -23,16 +24,14 @@ logion-shared = { path = "../logion-shared", default-features = false }
 scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.188", default-features = false, features = ["derive"] }
 sp-core = { git = "https://github.com/paritytech/polkadot-sdk", default-features = false, tag = "polkadot-v1.3.0" }
-sp-std = { git = "https://github.com/paritytech/polkadot-sdk", default-features = false, tag = "polkadot-v1.3.0" }
-
-[dev-dependencies]
-bs58 = "0.5.0"
 sp-io = { git = "https://github.com/paritytech/polkadot-sdk", default-features = false, tag = "polkadot-v1.3.0" }
 sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", default-features = false, tag = "polkadot-v1.3.0" }
+sp-std = { git = "https://github.com/paritytech/polkadot-sdk", default-features = false, tag = "polkadot-v1.3.0" }
 
 [features]
 default = ['std']
 std = [
+	'bs58/std',
 	'codec/std',
 	'frame-benchmarking?/std',
 	'frame-support/std',

--- a/pallet-lo-authority-list/src/benchmarking.rs
+++ b/pallet-lo-authority-list/src/benchmarking.rs
@@ -1,0 +1,132 @@
+//! Benchmarking setup for pallet-lo-authority-list
+#![cfg(feature = "runtime-benchmarks")]
+use super::*;
+
+use crate::{HostData, LegalOfficerData, LegalOfficerDataOf, Pallet as LoAuthorityList};
+
+extern crate alloc;
+use alloc::string::ToString;
+
+use frame_benchmarking::{account, impl_benchmark_test_suite, v2::*, BenchmarkError};
+use frame_support::{assert_ok, traits::OriginTrait};
+use frame_system::RawOrigin;
+
+use sp_core::OpaquePeerId;
+use sp_std::vec;
+
+#[benchmarks]
+mod benchmarks {
+    use super::*;
+
+    // Benchmark `add_legal_officer` extrinsic with the worst possible conditions:
+    // * Add host legal officer (causes re-computation of nodes set).
+    // * There are already "many" legal officers.
+    #[benchmark]
+    fn add_legal_officer() -> Result<(), BenchmarkError> {
+		let initial_lo_count = LoAuthorityList::<T>::legal_officers().len();
+        add_many_legal_officers::<T>();
+
+        #[extrinsic_call]
+        _(
+            RawOrigin::Root,
+            account_num::<T>(MANY_LO_COUNT),
+            host_data_num::<T>(MANY_LO_COUNT),
+        );
+
+        assert_eq!(
+            LoAuthorityList::<T>::legal_officers().len(),
+            initial_lo_count + (MANY_LO_COUNT as usize) + 1
+        );
+
+        Ok(())
+    }
+
+    // Benchmark `remove_legal_officer` extrinsic with the worst possible conditions:
+    // * Remove host legal officer (causes re-computation of nodes set).
+    // * There are already "many" legal officers.
+    #[benchmark]
+    fn remove_legal_officer() -> Result<(), BenchmarkError> {
+		let initial_lo_count = LoAuthorityList::<T>::legal_officers().len();
+        add_many_legal_officers::<T>();
+
+        #[extrinsic_call]
+        _(
+            RawOrigin::Root,
+            account_num::<T>(MANY_LO_COUNT - 1),
+        );
+
+        assert_eq!(
+            LoAuthorityList::<T>::legal_officers().len(),
+            initial_lo_count + (MANY_LO_COUNT as usize) - 1
+        );
+
+        Ok(())
+    }
+
+	// Benchmark `update_legal_officer` extrinsic with the worst possible conditions:
+    // * Update host legal officer (causes re-computation of nodes set).
+    // * There are already "many" legal officers.
+    #[benchmark]
+    fn update_legal_officer() -> Result<(), BenchmarkError> {
+		let initial_lo_count = LoAuthorityList::<T>::legal_officers().len();
+        add_many_legal_officers::<T>();
+
+        #[extrinsic_call]
+        _(
+            RawOrigin::Root,
+            account_num::<T>(MANY_LO_COUNT - 1),
+			LegalOfficerData::Host(HostData {
+				node_id: Some(OpaquePeerId(vec![(MANY_LO_COUNT - 1) as u8])),
+				base_url: Some(base_url_num::<T>(MANY_LO_COUNT)), // Change base URL
+				region: T::Region::from_str("Europe").ok().unwrap(),
+			}),
+        );
+
+        assert_eq!(
+            LoAuthorityList::<T>::legal_officers().len(),
+            initial_lo_count + (MANY_LO_COUNT as usize)
+        );
+
+        Ok(())
+    }
+
+    impl_benchmark_test_suite! {
+        LoAuthorityList,
+        crate::mock::new_test_ext(),
+        crate::mock::Test,
+    }
+}
+
+fn add_many_legal_officers<T: Config>() {
+	for i in 0..MANY_LO_COUNT {
+		assert_ok!(LoAuthorityList::<T>::add_legal_officer(
+			T::RuntimeOrigin::root(),
+			account_num::<T>(i),
+			host_data_num::<T>(i)
+		));
+	}
+}
+
+const MANY_LO_COUNT: u32 = 50;
+
+fn account_num<T: Config>(i: u32) -> T::AccountId {
+    account("lo", i, SEED)
+}
+
+const SEED: u32 = 0;
+
+fn base_url_num<T: Config>(i: u32) -> Vec<u8> {
+	let prefix = "https://node".as_bytes().to_vec();
+	let number = i.to_string().as_bytes().to_vec();
+	let suffix = ".logion.network".as_bytes().to_vec();
+	[prefix, number, suffix].concat()
+
+}
+
+fn host_data_num<T: Config>(i: u32) -> LegalOfficerDataOf<T> {
+    LegalOfficerData::Host(HostData {
+        node_id: Some(OpaquePeerId(vec![i as u8])),
+        base_url: Some(base_url_num::<T>(i)),
+        region: T::Region::from_str("Europe").ok().unwrap(),
+    })
+}

--- a/pallet-lo-authority-list/src/lib.rs
+++ b/pallet-lo-authority-list/src/lib.rs
@@ -1,5 +1,15 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
+pub mod migrations;
+
+#[cfg(test)]
+mod mock;
+#[cfg(test)]
+mod tests;
+
+#[cfg(feature = "runtime-benchmarks")]
+mod benchmarking;
+
 use codec::{Decode, Encode};
 
 use frame_support::dispatch::DispatchResultWithPostInfo;
@@ -22,14 +32,6 @@ use sp_std::{
 };
 
 pub use pallet::*;
-
-pub mod migrations;
-
-#[cfg(test)]
-mod mock;
-
-#[cfg(test)]
-mod tests;
 
 #[cfg(feature = "runtime-benchmarks")]
 use frame_system::RawOrigin;


### PR DESCRIPTION
* Adds missing benchmarks
* Can be unit tested with `cargo test --features runtime-benchmarks`, tests are then run against mock runtime (tests are generated by macro `impl_benchmark_test_suite`)
* Benchmarks run in the node are executed against the real runtime
* `initial_lo_count` variable is there to take into account the non-empty initial set of LOs in the real runtime

logion-network/logion-internal#1093