### PR TITLE
Invited contributor

### DIFF
--- a/pallet-block-reward/src/mock.rs
+++ b/pallet-block-reward/src/mock.rs
@@ -3,6 +3,7 @@ use crate::{self as pallet_block_reward, NegativeImbalanceOf};
 use frame_support::{
     construct_runtime, parameter_types, traits::Currency,
 };
+use frame_support::dispatch::RawOrigin;
 use frame_support::traits::EnsureOrigin;
 use frame_system as system;
 
@@ -123,6 +124,9 @@ parameter_types! {
     };
 }
 
+#[cfg(feature = "runtime-benchmarks")]
+pub type OuterOrigin<T> = <T as frame_system::Config>::RuntimeOrigin;
+
 pub struct LoAuthorityListMock;
 impl EnsureOrigin<RuntimeOrigin> for LoAuthorityListMock {
     type Success = <Test as system::Config>::AccountId;
@@ -130,6 +134,11 @@ impl EnsureOrigin<RuntimeOrigin> for LoAuthorityListMock {
     fn try_origin(o: <Test as system::Config>::RuntimeOrigin) -> Result<Self::Success, <Test as system::Config>::RuntimeOrigin> {
         <Self as IsLegalOfficer<<Test as system::Config>::AccountId, <Test as system::Config>::RuntimeOrigin>>::try_origin(o)
     }
+
+	#[cfg(feature = "runtime-benchmarks")]
+	fn try_successful_origin() -> Result<RuntimeOrigin, ()> {
+		Ok(OuterOrigin::<Test>::from(RawOrigin::Signed(LEGAL_OFFICER_ACCOUNT_1)))
+	}
 }
 
 impl IsLegalOfficer<<Test as system::Config>::AccountId, RuntimeOrigin> for LoAuthorityListMock {

--- a/pallet-logion-loc/src/benchmarking.rs
+++ b/pallet-logion-loc/src/benchmarking.rs
@@ -85,6 +85,7 @@ mod benchmarks {
 	fn create_polkadot_identity_loc() -> Result<(), BenchmarkError> {
 		let legal_officer_id = any_legal_officer::<T>();
 		let requester: T::AccountId = account("requester", 1, SEED);
+		create_closed_polkadot_identity_loc::<T>(T::LocIdFactory::loc_id(REQUESTER_IDENTITY_LOC_ID), &legal_officer_id, &requester);
 		ensure_enough_funds::<T>(&requester);
 		let items = many_items::<T>(&requester);
 		let next_loc_id: T::LocId = T::LocIdFactory::loc_id(NEXT_LOC_ID);
@@ -128,6 +129,7 @@ mod benchmarks {
 	fn create_polkadot_transaction_loc() -> Result<(), BenchmarkError> {
 		let legal_officer_id = any_legal_officer::<T>();
 		let requester: T::AccountId = account("requester", 1, SEED);
+		create_closed_polkadot_identity_loc::<T>(T::LocIdFactory::loc_id(REQUESTER_IDENTITY_LOC_ID), &legal_officer_id, &requester);
 		ensure_enough_funds::<T>(&requester);
 		let items = many_items::<T>(&requester);
 		let next_loc_id: T::LocId = T::LocIdFactory::loc_id(NEXT_LOC_ID);
@@ -183,6 +185,7 @@ mod benchmarks {
 	fn create_collection_loc() -> Result<(), BenchmarkError> {
 		let legal_officer_id = any_legal_officer::<T>();
 		let requester: T::AccountId = account("requester", 1, SEED);
+		create_closed_polkadot_identity_loc::<T>(T::LocIdFactory::loc_id(REQUESTER_IDENTITY_LOC_ID), &legal_officer_id, &requester);
 		ensure_enough_funds::<T>(&requester);
 		let items = many_items::<T>(&requester);
 		let next_loc_id: T::LocId = T::LocIdFactory::loc_id(NEXT_LOC_ID);
@@ -253,6 +256,7 @@ mod benchmarks {
 	fn add_link() -> Result<(), BenchmarkError> {
 		let legal_officer_id = any_legal_officer::<T>();
 		let requester: T::AccountId = account("requester", 1, SEED);
+		create_closed_polkadot_identity_loc::<T>(T::LocIdFactory::loc_id(REQUESTER_IDENTITY_LOC_ID), &legal_officer_id, &requester);
 		ensure_enough_funds::<T>(&requester);
 		create_locs_to_link_to::<T>(&requester); // Targets of the many links
 		create_loc::<T>(T::LocIdFactory::loc_id(MANY_ITEMS), &legal_officer_id, &requester); // New target
@@ -312,6 +316,7 @@ mod benchmarks {
 	fn add_collection_item() -> Result<(), BenchmarkError> {
 		let legal_officer_id = any_legal_officer::<T>();
 		let requester: T::AccountId = account("requester", 1, SEED);
+		create_closed_polkadot_identity_loc::<T>(T::LocIdFactory::loc_id(REQUESTER_IDENTITY_LOC_ID), &legal_officer_id, &requester);
 		ensure_enough_funds::<T>(&requester);
 
 		let loc_id: T::LocId = T::LocIdFactory::loc_id(0);
@@ -481,6 +486,7 @@ mod benchmarks {
 	fn add_tokens_record() -> Result<(), BenchmarkError> {
 		let legal_officer_id = any_legal_officer::<T>();
 		let requester: T::AccountId = account("requester", 1, SEED);
+		create_closed_polkadot_identity_loc::<T>(T::LocIdFactory::loc_id(REQUESTER_IDENTITY_LOC_ID), &legal_officer_id, &requester);
 		ensure_enough_funds::<T>(&requester);
 
 		let loc_id: T::LocId = T::LocIdFactory::loc_id(0);
@@ -602,6 +608,7 @@ mod benchmarks {
 	fn acknowledge_metadata() -> Result<(), BenchmarkError> {
 		let legal_officer_id = any_legal_officer::<T>();
 		let requester: T::AccountId = account("requester", 1, SEED);
+		create_closed_polkadot_identity_loc::<T>(T::LocIdFactory::loc_id(REQUESTER_IDENTITY_LOC_ID), &legal_officer_id, &requester);
 		ensure_enough_funds::<T>(&requester);
 
 		let loc_id: T::LocId = T::LocIdFactory::loc_id(0);
@@ -637,6 +644,7 @@ mod benchmarks {
 	fn acknowledge_file() -> Result<(), BenchmarkError> {
 		let legal_officer_id = any_legal_officer::<T>();
 		let requester: T::AccountId = account("requester", 1, SEED);
+		create_closed_polkadot_identity_loc::<T>(T::LocIdFactory::loc_id(REQUESTER_IDENTITY_LOC_ID), &legal_officer_id, &requester);
 		ensure_enough_funds::<T>(&requester);
 
 		let loc_id: T::LocId = T::LocIdFactory::loc_id(0);
@@ -672,6 +680,7 @@ mod benchmarks {
 	fn acknowledge_link() -> Result<(), BenchmarkError> {
 		let legal_officer_id = any_legal_officer::<T>();
 		let requester: T::AccountId = account("requester", 1, SEED);
+		create_closed_polkadot_identity_loc::<T>(T::LocIdFactory::loc_id(REQUESTER_IDENTITY_LOC_ID), &legal_officer_id, &requester);
 		ensure_enough_funds::<T>(&requester);
 		create_locs_to_link_to::<T>(&requester); // Targets of the many links
 
@@ -708,6 +717,7 @@ mod benchmarks {
 	fn close() -> Result<(), BenchmarkError> {
 		let legal_officer_id = any_legal_officer::<T>();
 		let requester: T::AccountId = account("requester", 1, SEED);
+		create_closed_polkadot_identity_loc::<T>(T::LocIdFactory::loc_id(REQUESTER_IDENTITY_LOC_ID), &legal_officer_id, &requester);
 		ensure_enough_funds::<T>(&requester);
 		let items = many_items::<T>(&requester);
 		let next_loc_id: T::LocId = T::LocIdFactory::loc_id(NEXT_LOC_ID);
@@ -908,6 +918,7 @@ const INVITED_CONTRIBUTOR_IDENTITY_LOC_ID: u32 = NEXT_LOC_ID + 3;
 fn setup_empty_loc<T: pallet::Config>() -> (T::LocId, T::AccountId) {
 	let legal_officer_id = any_legal_officer::<T>();
 	let requester: T::AccountId = account("requester", 1, SEED);
+	create_closed_polkadot_identity_loc::<T>(T::LocIdFactory::loc_id(REQUESTER_IDENTITY_LOC_ID), &legal_officer_id, &requester);
 	ensure_enough_funds::<T>(&requester);
 	let loc_id: T::LocId = T::LocIdFactory::loc_id(0);
 	create_loc::<T>(loc_id, &legal_officer_id, &requester);

--- a/pallet-logion-loc/src/lib.rs
+++ b/pallet-logion-loc/src/lib.rs
@@ -984,6 +984,8 @@ pub mod pallet {
                 Err(Error::<T>::Unauthorized)?
             } else if <LocMap<T>>::contains_key(&loc_id) {
                 Err(Error::<T>::AlreadyExists)?
+			} else if !Self::has_closed_identity_loc(&requester_account_id, &legal_officer) {
+				Err(Error::<T>::AccountNotIdentified)?
             } else {
                 let requester = RequesterOf::<T>::Account(requester_account_id.clone());
                 let mut loc = Self::build_open_loc(&legal_officer, &requester, LocType::Transaction, None, legal_fee);
@@ -1059,7 +1061,9 @@ pub mod pallet {
                 Err(Error::<T>::Unauthorized)?
             } else if collection_last_block_submission.is_none() && collection_max_size.is_none() {
                 Err(Error::<T>::CollectionHasNoLimit)?
-            }
+            } else if !Self::has_closed_identity_loc(&requester_account_id, &legal_officer) {
+				Err(Error::<T>::AccountNotIdentified)?
+			}
 
             if <LocMap<T>>::contains_key(&loc_id) {
                 Err(Error::<T>::AlreadyExists)?

--- a/pallet-logion-loc/src/lib.rs
+++ b/pallet-logion-loc/src/lib.rs
@@ -708,7 +708,19 @@ pub mod pallet {
     #[pallet::getter(fn sponsorship)]
     pub type SponsorshipMap<T> = StorageMap<_, Blake2_128Concat, <T as Config>::SponsorshipId, SponsorshipOf<T>>;
 
-    #[pallet::event]
+	/// Invited Contributors by LOC
+	#[pallet::storage]
+	#[pallet::getter(fn selected_invited_contributors)]
+	pub type InvitedContributorsByLocMap<T> = StorageDoubleMap<
+		_,
+		Blake2_128Concat,
+		<T as Config>::LocId,
+		Blake2_128Concat,
+		<T as frame_system::Config>::AccountId, // invited contributor
+		()
+	>;
+
+	#[pallet::event]
     #[pallet::generate_deposit(pub(super) fn deposit_event)]
     pub enum Event<T: Config> {
         /// Issued upon LOC creation. [locId]
@@ -836,6 +848,8 @@ pub mod pallet {
         BadTokenIssuance,
         /// There is still at least one Item (Metadata, Link or File) unacknowledged by verified issuer
         CannotCloseUnacknowledgedByVerifiedIssuer,
+		/// The provided Polkadot account has no closed, non-void identity LOC
+		AccountNotIdentified,
     }
 
     #[pallet::hooks]
@@ -1700,6 +1714,43 @@ pub mod pallet {
                 }
             }
         }
+
+		/// Select/unselect an invited contributor on a given LOC
+		#[pallet::call_index(25)]
+		#[pallet::weight(T::WeightInfo::set_issuer_selection())]
+		pub fn set_invited_contributor_selection(
+			origin: OriginFor<T>,
+			#[pallet::compact] loc_id: T::LocId,
+			invited_contributor: T::AccountId,
+			selected: bool,
+		) -> DispatchResultWithPostInfo {
+			let who = ensure_signed(origin)?;
+			if !<LocMap<T>>::contains_key(&loc_id) {
+				Err(Error::<T>::NotFound)?
+			} else {
+				let loc = <LocMap<T>>::get(&loc_id).unwrap();
+				match &loc.requester {
+					Account(requester_account) =>
+						if requester_account.clone() != who {
+							Err(Error::<T>::Unauthorized)?
+						},
+					_ => Err(Error::<T>::Unauthorized)?
+				};
+				if loc.void_info.is_some() {
+					Err(Error::<T>::CannotMutateVoid)?
+				} else if !Self::has_closed_identity_loc(&invited_contributor, &loc.owner) {
+					Err(Error::<T>::AccountNotIdentified)?
+				} else {
+					let already_invited_contributor = Self::selected_invited_contributors(loc_id, &invited_contributor);
+					if already_invited_contributor.is_some() && !selected {
+						<InvitedContributorsByLocMap<T>>::remove(loc_id, &invited_contributor);
+					} else if already_invited_contributor.is_none() && selected {
+						<InvitedContributorsByLocMap<T>>::insert(loc_id, &invited_contributor, ());
+					}
+					Ok(().into())
+				}
+			}
+		}
     }
 
     impl<T: Config> LocQuery<T::LocId, <T as frame_system::Config>::AccountId> for Pallet<T> {
@@ -2076,6 +2127,7 @@ pub mod pallet {
                     match &collection_loc.requester { Account(requester) => requester == adder, _ => false }
                     || *adder == collection_loc.owner
                     || Self::selected_verified_issuers(loc_id, adder).is_some()
+                    || Self::selected_invited_contributors(loc_id, adder).is_some()
                 )
                 && collection_loc.closed
                 && collection_loc.void_info.is_none()

--- a/pallet-logion-loc/src/lib.rs
+++ b/pallet-logion-loc/src/lib.rs
@@ -1721,7 +1721,7 @@ pub mod pallet {
 
 		/// Select/unselect an invited contributor on a given LOC
 		#[pallet::call_index(25)]
-		#[pallet::weight(T::WeightInfo::set_issuer_selection())]
+		#[pallet::weight(T::WeightInfo::set_invited_contributor_selection())]
 		pub fn set_invited_contributor_selection(
 			origin: OriginFor<T>,
 			#[pallet::compact] loc_id: T::LocId,

--- a/pallet-logion-loc/src/mock.rs
+++ b/pallet-logion-loc/src/mock.rs
@@ -90,6 +90,7 @@ pub const ISSUER_ID2: u64 = 6;
 pub const SPONSOR_ID: u64 = 7;
 pub const LOGION_TREASURY_ACCOUNT_ID: u64 = 8;
 pub const UNAUTHORIZED_CALLER: u64 = 9;
+pub const INVITED_CONTRIBUTOR_ID: u64 = 10;
 
 #[cfg(feature = "runtime-benchmarks")]
 pub type OuterOrigin<T> = <T as frame_system::Config>::RuntimeOrigin;

--- a/pallet-logion-loc/src/weights.rs
+++ b/pallet-logion-loc/src/weights.rs
@@ -59,6 +59,7 @@ pub trait WeightInfo {
     fn acknowledge_metadata() -> Weight;
     fn acknowledge_file() -> Weight;
     fn acknowledge_link() -> Weight;
+    fn set_invited_contributor_selection() -> Weight;
 }
 
 /// Weights for pallet_logion_loc using the Substrate node and recommended hardware.
@@ -165,18 +166,21 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
             .saturating_add(T::DbWeight::get().reads(1))
             .saturating_add(T::DbWeight::get().writes(1))
     }
-
     fn acknowledge_file() -> Weight {
         Weight::from_parts(11_979_000, 0)
             .saturating_add(T::DbWeight::get().reads(1))
             .saturating_add(T::DbWeight::get().writes(1))
     }
-
     fn acknowledge_link() -> Weight {
         Weight::from_parts(11_979_000, 0)
             .saturating_add(T::DbWeight::get().reads(1))
             .saturating_add(T::DbWeight::get().writes(1))
     }
+	fn set_invited_contributor_selection() -> Weight {
+		Weight::from_parts(11_971_000, 0)
+			.saturating_add(T::DbWeight::get().reads(1))
+			.saturating_add(T::DbWeight::get().writes(1))
+	}
 }
 
 // For backwards compatibility and tests
@@ -291,4 +295,9 @@ impl WeightInfo for () {
             .saturating_add(RocksDbWeight::get().reads(1))
             .saturating_add(RocksDbWeight::get().writes(1))
     }
+	fn set_invited_contributor_selection() -> Weight {
+		Weight::from_parts(11_971_000, 0)
+			.saturating_add(RocksDbWeight::get().reads(1))
+			.saturating_add(RocksDbWeight::get().writes(1))
+	}
 }

--- a/pallet-logion-vault/src/mock.rs
+++ b/pallet-logion-vault/src/mock.rs
@@ -3,6 +3,7 @@ use logion_shared::{IsLegalOfficer, MultisigApproveAsMultiCallFactory, MultisigA
 use pallet_multisig::Timepoint;
 use sp_core::hash::H256;
 use frame_support::{parameter_types, traits::EnsureOrigin};
+use frame_support::dispatch::RawOrigin;
 use sp_runtime::{
     traits::{BlakeTwo256, IdentityLookup}, testing::Header, generic, BuildStorage,
 };
@@ -94,6 +95,9 @@ impl IsLegalOfficer<<Test as system::Config>::AccountId, RuntimeOrigin> for IsLe
     }
 }
 
+#[cfg(feature = "runtime-benchmarks")]
+pub type OuterOrigin<T> = <T as frame_system::Config>::RuntimeOrigin;
+
 impl EnsureOrigin<RuntimeOrigin> for IsLegalOfficerMock {
     type Success = <Test as system::Config>::AccountId;
 
@@ -110,6 +114,11 @@ impl EnsureOrigin<RuntimeOrigin> for IsLegalOfficerMock {
             Err(_) => Err(o)
         }
     }
+
+	#[cfg(feature = "runtime-benchmarks")]
+	fn try_successful_origin() -> Result<RuntimeOrigin, ()> {
+		Ok(OuterOrigin::<Test>::from(RawOrigin::Signed(LEGAL_OFFICER1)))
+	}
 }
 
 impl pallet_logion_vault::Config for Test {


### PR DESCRIPTION
* Add possibility for (non-void) LOC requester to add/remove Invited Contributors.
* Invited Contributor must have a valid (i.e. closed, non-void, same owner as contributed LOC) identity LOC.
* Contributor may only add tokens records.
___
* Additionally, the creation of LOC (Transaction or Collection) by requester is now forbidden if the requester has no valid identity LOC.
___
logion-network/logion-internal#1118