### PR TITLE
BoundedVec's for pallet-logion-vote

### DIFF
--- a/pallet-logion-vote/src/mock.rs
+++ b/pallet-logion-vote/src/mock.rs
@@ -28,6 +28,7 @@ pub struct LoAuthorityListMock;
 pub type OuterOrigin<T> = <T as frame_system::Config>::RuntimeOrigin;
 #[cfg(feature = "runtime-benchmarks")]
 use frame_system::RawOrigin;
+use scale_info::TypeInfo;
 
 impl EnsureOrigin<RuntimeOrigin> for LoAuthorityListMock {
     type Success = <Test as system::Config>::AccountId;
@@ -146,6 +147,11 @@ impl LocSetup<LocId, AccountId> for LocSetupMock {
 	}
 }
 
+parameter_types! {
+	#[derive(Debug, PartialEq, TypeInfo)]
+	pub const MaxBallots: u32 = 2;
+}
+
 impl pallet_logion_vote::Config for Test {
     type LocId = LocId;
     type RuntimeEvent = RuntimeEvent;
@@ -154,6 +160,7 @@ impl pallet_logion_vote::Config for Test {
     type LocQuery = LocQueryMock;
     type LegalOfficerCreation = LegalOfficerCreationMock;
     type WeightInfo = SubstrateWeight<Test>;
+	type MaxBallots = MaxBallots;
 	#[cfg(feature = "runtime-benchmarks")]
 	type LocSetup = LocSetupMock;
 }

--- a/pallet-logion-vote/src/tests.rs
+++ b/pallet-logion-vote/src/tests.rs
@@ -1,4 +1,5 @@
 use frame_support::{assert_err, assert_ok};
+use sp_core::bounded::BoundedVec;
 use sp_runtime::DispatchError::BadOrigin;
 
 use crate::{Ballot, BallotStatus, Error, Event, Vote};
@@ -17,10 +18,10 @@ fn it_creates_vote() {
         assert_eq!(LogionVote::votes(1), Some(
             Vote {
                 loc_id: LOC_ID,
-                ballots: vec![
+                ballots: BoundedVec::try_from(vec![
                     Ballot { voter: legal_officer_id(1), status: BallotStatus::NotVoted },
                     Ballot { voter: legal_officer_id(2), status: BallotStatus::NotVoted },
-                ]
+				]).expect("Failed to create expected BoundedVec")
             }));
         assert_eq!(LogionVote::votes(2), None);
         assert_eq!(LogionVote::is_vote_closed_and_approved(vote_id), (false, false));
@@ -59,10 +60,10 @@ fn it_votes_yes() {
         assert_eq!(LogionVote::votes(vote_id), Some(
             Vote {
                 loc_id: LOC_ID,
-                ballots: vec![
+				ballots: BoundedVec::try_from(vec![
                     Ballot { voter: legal_officer_id(1), status: BallotStatus::VotedYes },
                     Ballot { voter: legal_officer_id(2), status: BallotStatus::NotVoted },
-                ]
+				]).expect("Failed to create expected BoundedVec")
             }));
         assert_eq!(LogionVote::is_vote_closed_and_approved(vote_id), (false, false));
         System::assert_has_event(Event::VoteUpdated(
@@ -85,10 +86,10 @@ fn it_votes_yes_and_no() {
         assert_eq!(LogionVote::votes(vote_id), Some(
             Vote {
                 loc_id: LOC_ID,
-                ballots: vec![
+				ballots: BoundedVec::try_from(vec![
                     Ballot { voter: legal_officer_id(1), status: BallotStatus::VotedYes },
                     Ballot { voter: legal_officer_id(2), status: BallotStatus::VotedNo },
-                ]
+				]).expect("Failed to create expected BoundedVec")
             }));
         assert_eq!(LogionVote::is_vote_closed_and_approved(vote_id), (true, false));
         System::assert_has_event(Event::VoteUpdated(
@@ -117,10 +118,10 @@ fn it_votes_yes_and_yes() {
         assert_eq!(LogionVote::votes(vote_id), Some(
             Vote {
                 loc_id: LOC_ID,
-                ballots: vec![
+                ballots: BoundedVec::try_from(vec![
                     Ballot { voter: legal_officer_id(1), status: BallotStatus::VotedYes },
                     Ballot { voter: legal_officer_id(2), status: BallotStatus::VotedYes },
-                ]
+                ]).expect("Failed to create expected BoundedVec")
             }));
         assert_eq!(LogionVote::is_vote_closed_and_approved(vote_id), (true, true));
         System::assert_has_event(Event::VoteUpdated(


### PR DESCRIPTION
* Remove #[pallet::without_storage_info];
* Use configurable `BoundedVec` for Ballot lists.
### Notes about configuration:
* config value `MaxBallots` should be equal to maximum number of legal officers, configured in `pallet-lo-authority-list`.
* The related overflow condition (error `TooMuchBallots`) is very difficult to test, it requires specific mock. Yet someone can test error is thrown by temporarily setting value to 1, run all tests and see most of them all fail with `TooMuchBallots`.
```rust
pub const MaxBallots: u32 = 1;
```
logion-network/logion-internal#488