### PR TITLE
Use bounded storage in pallet-lo-authority-list

### DIFF
--- a/pallet-lo-authority-list/src/lib.rs
+++ b/pallet-lo-authority-list/src/lib.rs
@@ -10,22 +10,18 @@ mod tests;
 #[cfg(feature = "runtime-benchmarks")]
 mod benchmarking;
 
-use codec::{Decode, Encode};
+use codec::{Decode, Encode, MaxEncodedLen};
 
 use frame_support::dispatch::DispatchResultWithPostInfo;
 use sp_runtime::traits::BadOrigin;
-use frame_support::{
-    sp_runtime,
-    traits::EnsureOrigin,
-};
+use frame_support::{BoundedVec, ensure, sp_runtime, traits::EnsureOrigin};
 
 use logion_shared::{IsLegalOfficer, LegalOfficerCreation};
 use scale_info::{TypeInfo, prelude::string::String};
 use serde::{Deserialize, Serialize};
 
-use sp_core::OpaquePeerId as PeerId;
+use sp_core::{Get, OpaquePeerId as PeerId};
 use sp_std::{
-    collections::btree_set::BTreeSet,
     fmt::Debug,
     str::FromStr,
     vec::Vec
@@ -35,6 +31,7 @@ pub use pallet::*;
 
 #[cfg(feature = "runtime-benchmarks")]
 use frame_system::RawOrigin;
+use sp_core::bounded::BoundedBTreeSet;
 
 pub trait GenesisRegion<Region>: Into<Region> {}
 
@@ -45,25 +42,46 @@ pub struct GenesisHostData {
     pub region: String,
 }
 
-#[derive(Encode, Decode, Clone, PartialEq, Eq, Debug, TypeInfo)]
-pub enum LegalOfficerData<AccountId, Region> {
-    Host(HostData<Region>),
+#[derive(Encode, Decode, Clone, PartialEq, Eq, Debug, TypeInfo, MaxEncodedLen)]
+pub enum LegalOfficerData<AccountId, Region, MaxBaseUrlLen: Get<u32>> {
+    Host(HostData<Region, MaxBaseUrlLen>),
     Guest(AccountId),
 }
 
 pub type LegalOfficerDataOf<T> = LegalOfficerData<
     <T as frame_system::Config>::AccountId,
     <T as Config>::Region,
+    <T as Config>::MaxBaseUrlLen,
 >;
 
 #[derive(Encode, Decode, Clone, PartialEq, Eq, Debug, TypeInfo)]
-pub struct HostData<Region> {
+pub struct HostData<Region, MaxBaseUrlLen: Get<u32>> {
     pub node_id: Option<PeerId>,
-    pub base_url: Option<Vec<u8>>,
+	pub base_url: Option<BoundedVec<u8, MaxBaseUrlLen>>,
     pub region: Region,
 }
 
-pub type HostDataOf<T> = HostData<<T as Config>::Region>;
+pub type HostDataOf<T> = HostData<<T as Config>::Region, <T as Config>::MaxBaseUrlLen>;
+
+#[derive(Encode, Decode, Clone, PartialEq, Eq, Debug, TypeInfo)]
+pub enum LegalOfficerDataParam<AccountId, Region> {
+	Host(HostDataParam<Region>),
+	Guest(AccountId),
+}
+
+pub type LegalOfficerDataParamOf<T> = LegalOfficerDataParam<
+	<T as frame_system::Config>::AccountId,
+	<T as Config>::Region,
+>;
+
+#[derive(Encode, Decode, Clone, PartialEq, Eq, Debug, TypeInfo)]
+pub struct HostDataParam<Region> {
+	pub node_id: Option<PeerId>,
+	pub base_url: Option<Vec<u8>>,
+	pub region: Region,
+}
+
+pub type HostDataParamOf<T> = HostDataParam<<T as Config>::Region>;
 
 pub mod weights;
 
@@ -90,17 +108,26 @@ pub mod pallet {
         type UpdateOrigin: EnsureOrigin<Self::RuntimeOrigin>;
 
         /// The Legal Officers region
-        type Region: frame_support::pallet_prelude::Member + frame_support::pallet_prelude::Parameter + Copy + FromStr + Default;
+        type Region: frame_support::pallet_prelude::Member + frame_support::pallet_prelude::Parameter + Copy + FromStr + Default + MaxEncodedLen;
 
         /// The overarching event type.
         type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
 
         /// Weight information for extrinsics in this pallet.
         type WeightInfo: WeightInfo;
-    }
+
+		/// The Maximum size of base_url
+		type MaxBaseUrlLen: Get<u32> + Member + TypeInfo;
+
+		/// The Maximum number of nodes
+		type MaxNodes: Get<u32>;
+
+		/// The maximum length in bytes of PeerId
+		type MaxPeerIdLength: Get<u32>;
+	}
 
     #[pallet::pallet]
-    #[pallet::without_storage_info]
+	#[pallet::without_storage_info]
     pub struct Pallet<T>(_);
 
     /// All LOs indexed by their account ID.
@@ -116,19 +143,20 @@ pub mod pallet {
     /// The set of LO nodes.
     #[pallet::storage]
     #[pallet::getter(fn legal_officer_nodes)]
-    pub type LegalOfficerNodes<T> = StorageValue<_, BTreeSet<PeerId>, ValueQuery>;
+    pub type LegalOfficerNodes<T> = StorageValue<_, BoundedBTreeSet<PeerId, <T as pallet::Config>::MaxNodes>, ValueQuery>;
 
-    #[derive(Encode, Decode, Eq, PartialEq, Debug, TypeInfo)]
+    #[derive(Encode, Decode, Eq, PartialEq, Debug, TypeInfo, MaxEncodedLen)]
     pub enum StorageVersion {
         V1,
         V2AddOnchainSettings,
         V3GuestLegalOfficers,
         V4Region,
+        V5BoundedVec,
     }
 
     impl Default for StorageVersion {
         fn default() -> StorageVersion {
-            return StorageVersion::V3GuestLegalOfficers;
+            return StorageVersion::V4Region;
         }
     }
 
@@ -153,18 +181,7 @@ pub mod pallet {
     where <T::Region as FromStr>::Err: Debug
     {
         fn build(&self) {
-            let legal_officers: Vec<(T::AccountId, HostData<T::Region>)> = self.legal_officers.iter().map(|data| {
-                let region: T::Region = FromStr::from_str(&data.1.region).unwrap();
-                (
-                    data.0.clone(),
-                    HostData {
-                        node_id: data.1.node_id.clone(),
-                        base_url: data.1.base_url.clone(),
-                        region,
-                    }
-                )
-            }).collect();
-            Pallet::<T>::initialize_legal_officers(&legal_officers);
+            Pallet::<T>::initialize_legal_officers(&self.legal_officers);
         }
     }
 
@@ -199,7 +216,13 @@ pub mod pallet {
         GuestCannotUpdate,
         /// LO cannot change region
         CannotChangeRegion,
-    }
+		/// There are too much nodes
+		TooManyNodes,
+		/// The base url is too long
+		BaseUrlTooLong,
+		/// The PeerId is too long
+		PeerIdTooLong,
+	}
 
     #[pallet::hooks]
     impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
@@ -213,12 +236,13 @@ pub mod pallet {
         pub fn add_legal_officer(
             origin: OriginFor<T>,
             legal_officer_id: T::AccountId,
-            data: LegalOfficerDataOf<T>,
+            data: LegalOfficerDataParamOf<T>,
         ) -> DispatchResultWithPostInfo {
             T::AddOrigin::ensure_origin(origin)?;
+			let bounded_data = Self::map_to_bounded_legal_officer_data(&data)?;
             Self::do_add_legal_officer(
                 legal_officer_id,
-                data
+				bounded_data
             )
         }
 
@@ -248,9 +272,9 @@ pub mod pallet {
         #[pallet::call_index(2)]
         #[pallet::weight(T::WeightInfo::update_legal_officer())]
         pub fn update_legal_officer(
-            origin: OriginFor<T>,
-            legal_officer_id: T::AccountId,
-            data: LegalOfficerDataOf<T>,
+			origin: OriginFor<T>,
+			legal_officer_id: T::AccountId,
+			data: LegalOfficerDataParamOf<T>,
         ) -> DispatchResultWithPostInfo {
             let who = ensure_signed_or_root(origin.clone())?;
             if who.is_some() && who.clone().unwrap() != legal_officer_id {
@@ -260,10 +284,11 @@ pub mod pallet {
             if to_update.is_none() {
                 Err(Error::<T>::NotFound)?
             } else {
-                Self::ensure_host_if_guest(&data)?;
+				let bounded_data = Self::map_to_bounded_legal_officer_data(&data)?;
+                Self::ensure_host_if_guest(&bounded_data)?;
                 let some_to_update = to_update.unwrap();
                 match some_to_update {
-                    LegalOfficerData::Host(_) => match data {
+                    LegalOfficerData::Host(_) => match bounded_data {
                         LegalOfficerData::Guest(_) => {
                             if Self::host_has_guest(&legal_officer_id) {
                                 Err(Error::<T>::HostHasGuest)?
@@ -280,14 +305,14 @@ pub mod pallet {
                 }
 
                 let source_region = Self::get_region(&some_to_update);
-                let dest_region = Self::get_region(&data);
+                let dest_region = Self::get_region(&bounded_data);
                 if source_region != dest_region {
                     Err(Error::<T>::CannotChangeRegion)?
                 }
 
-                <LegalOfficerSet<T>>::set(legal_officer_id.clone(), Some(data.clone()));
+                <LegalOfficerSet<T>>::set(legal_officer_id.clone(), Some(bounded_data.clone()));
                 match some_to_update {
-                    LegalOfficerData::Guest(_) => match data {
+                    LegalOfficerData::Guest(_) => match bounded_data {
                         LegalOfficerData::Host(_) => Self::reset_legal_officer_nodes()?,
                         LegalOfficerData::Guest(_) => (),
                     },
@@ -306,14 +331,25 @@ pub mod pallet {
 pub type OuterOrigin<T> = <T as frame_system::Config>::RuntimeOrigin;
 
 impl<T: Config> Pallet<T> {
-    fn initialize_legal_officers(legal_officers: &Vec<(T::AccountId, HostData<T::Region>)>)
-    where <T::Region as FromStr>::Err: Debug
-    {
-        for legal_officer in legal_officers {
-            LegalOfficerSet::<T>::insert::<&T::AccountId, &LegalOfficerDataOf<T>>(&(legal_officer.0), &LegalOfficerData::Host(legal_officer.1.clone()));
-            LegalOfficerNodes::<T>::set(BTreeSet::new());
-        }
-    }
+	fn initialize_legal_officers(legal_officers: &Vec<(T::AccountId, GenesisHostData)>)
+		where <T::Region as FromStr>::Err: Debug
+	{
+		for legal_officer in legal_officers {
+			let region: T::Region = FromStr::from_str(&legal_officer.1.region).unwrap();
+			let base_url = match legal_officer.1.base_url.clone() {
+				Some(url) => Some(BoundedVec::try_from(url).unwrap()),
+				None => None,
+			};
+			let llo_data = &LegalOfficerData::Host(HostData {
+				node_id: legal_officer.1.node_id.clone(),
+				base_url,
+				region,
+			}
+			);
+			LegalOfficerSet::<T>::insert::<&T::AccountId, &LegalOfficerDataOf<T>>(&(legal_officer.0), llo_data);
+			LegalOfficerNodes::<T>::set(BoundedBTreeSet::new());
+		}
+	}
 
     fn try_reset_legal_officer_nodes(added_or_removed_data: &LegalOfficerDataOf<T>) -> Result<(), Error<T>> {
         match added_or_removed_data {
@@ -323,13 +359,20 @@ impl<T: Config> Pallet<T> {
     }
 
     fn reset_legal_officer_nodes() -> Result<(), Error<T>> {
-        let mut new_nodes = BTreeSet::new();
+        let mut new_nodes: BoundedBTreeSet<PeerId, <T as pallet::Config>::MaxNodes> = BoundedBTreeSet::new();
         for data in LegalOfficerSet::<T>::iter_values() {
             match data {
                 LegalOfficerData::Host(host_data) => {
-                    if host_data.node_id.is_some() && ! new_nodes.insert(host_data.node_id.unwrap()) {
-                        Err(Error::<T>::PeerIdAlreadyInUse)?
-                    }
+					match host_data.node_id {
+						Some(node_id) => {
+							let inserted = new_nodes.try_insert(node_id)
+								.map_err(|_| Error::<T>::TooManyNodes)?;
+							if !inserted {
+								Err(Error::<T>::PeerIdAlreadyInUse)?
+							}
+						}
+						None => {},
+					}
                 },
                 _ => (),
             }
@@ -394,6 +437,35 @@ impl<T: Config> Pallet<T> {
             LegalOfficerData::Host(host_data) => host_data.region,
         }
     }
+
+	fn map_to_bounded_legal_officer_data(data: &LegalOfficerDataParamOf<T>) -> Result<LegalOfficerDataOf<T>, Error<T>> {
+		let bounded_data = match data {
+			LegalOfficerDataParam::Host(host_data) => {
+				let base_url = match host_data.base_url.clone() {
+					Some(url) => {
+						let bounded_url = BoundedVec::try_from(url)
+							.map_err(|_| Error::<T>::BaseUrlTooLong)?;
+						Some(bounded_url)
+					},
+					None => None,
+				};
+				ensure!(
+					host_data.node_id.is_none() ||
+					host_data.node_id.as_ref().unwrap().0.len() <= T::MaxPeerIdLength::get() as usize,
+					Error::<T>::PeerIdTooLong
+				);
+				LegalOfficerData::Host(
+					HostData {
+						node_id: host_data.node_id.clone(),
+						base_url,
+						region: host_data.region,
+					}
+				)
+			},
+			LegalOfficerDataParam::Guest(account_id) => LegalOfficerData::Guest(account_id.clone()),
+		};
+		Ok(bounded_data)
+	}
 }
 
 impl<T: Config> EnsureOrigin<T::RuntimeOrigin> for Pallet<T> {

--- a/pallet-lo-authority-list/src/migrations.rs
+++ b/pallet-lo-authority-list/src/migrations.rs
@@ -1,29 +1,9 @@
 use frame_support::traits::Get;
 use frame_support::weights::Weight;
-use frame_support::traits::OnRuntimeUpgrade;
 
 use crate::{Config, PalletStorageVersion, pallet::StorageVersion};
 
-pub mod v4 {
-    use super::*;
-    use crate::*;
-
-    pub struct Dummy<T>(sp_std::marker::PhantomData<T>);
-    impl<T: Config> OnRuntimeUpgrade for Dummy<T> {
-
-        fn on_runtime_upgrade() -> Weight {
-            super::do_storage_upgrade::<T, _>(
-                StorageVersion::V4Region,
-                StorageVersion::V4Region,
-                "Dummy",
-                || {
-                    LegalOfficerSet::<T>::translate_values(|legal_officer_data: LegalOfficerDataOf<T>| { Some(legal_officer_data) } );
-                }
-            )
-        }
-    }
-}
-
+#[allow(dead_code)]
 fn do_storage_upgrade<T: Config, F>(expected_version: StorageVersion, target_version: StorageVersion, migration_name: &str, migration: F) -> Weight
 where F: FnOnce() -> () {
     let storage_version = PalletStorageVersion::<T>::get();

--- a/pallet-lo-authority-list/src/migrations.rs
+++ b/pallet-lo-authority-list/src/migrations.rs
@@ -4,42 +4,47 @@ use frame_support::traits::OnRuntimeUpgrade;
 
 use crate::{Config, PalletStorageVersion, pallet::StorageVersion};
 
-pub mod v4 {
+pub mod v5 {
     use super::*;
     use crate::*;
 
     #[derive(Encode, Decode, Clone, PartialEq, Eq, Debug, TypeInfo)]
-    pub enum LegalOfficerDataV3<AccountId> {
-        Host(HostDataV3),
+    pub enum LegalOfficerDataV4<AccountId, Region> {
+        Host(HostDataV4<Region>),
         Guest(AccountId),
     }
 
-    pub type LegalOfficerDataV3Of<T> = LegalOfficerDataV3<
+    pub type LegalOfficerDataV4Of<T> = LegalOfficerDataV4<
         <T as frame_system::Config>::AccountId,
+        <T as pallet::Config>::Region,
     >;
 
     #[derive(Encode, Decode, Clone, PartialEq, Eq, Debug, TypeInfo)]
-    pub struct HostDataV3 {
-        pub node_id: Option<PeerId>,
-        pub base_url: Option<Vec<u8>>,
+    pub struct HostDataV4<Region> {
+		pub node_id: Option<PeerId>,
+		pub base_url: Option<Vec<u8>>,
+		pub region: Region,
     }
 
-    pub struct AddRegion<T>(sp_std::marker::PhantomData<T>);
-    impl<T: Config> OnRuntimeUpgrade for AddRegion<T> {
+    pub struct BoundedBaseUrl<T>(sp_std::marker::PhantomData<T>);
+    impl<T: Config> OnRuntimeUpgrade for BoundedBaseUrl<T> {
 
         fn on_runtime_upgrade() -> Weight {
             super::do_storage_upgrade::<T, _>(
-                StorageVersion::V3GuestLegalOfficers,
                 StorageVersion::V4Region,
-                "AddRegion",
+                StorageVersion::V4Region,
+                "BoundedBaseUrl",
                 || {
-                    LegalOfficerSet::<T>::translate_values(|legal_officer_data: LegalOfficerDataV3Of<T>| {
+                    LegalOfficerSet::<T>::translate_values(|legal_officer_data: LegalOfficerDataV4Of<T>| {
                         match legal_officer_data {
-                            LegalOfficerDataV3::Guest(guest_data) => Some(LegalOfficerData::Guest(guest_data)),
-                            LegalOfficerDataV3::Host(host_data) => Some(LegalOfficerData::Host(HostData {
+                            LegalOfficerDataV4::Guest(guest_data) => Some(LegalOfficerData::Guest(guest_data)),
+                            LegalOfficerDataV4::Host(host_data) => Some(LegalOfficerData::Host(HostData {
                                 node_id: host_data.node_id.clone(),
-                                base_url: host_data.base_url.clone(),
-                                region: Default::default(),
+                                base_url: match host_data.base_url {
+									None => None,
+									Some(url) => Some(BoundedVec::try_from(url).expect("Failed to migrate base_url")),
+								},
+                                region: host_data.region.clone(),
                             })),
                         }
                     })

--- a/pallet-lo-authority-list/src/migrations.rs
+++ b/pallet-lo-authority-list/src/migrations.rs
@@ -4,50 +4,20 @@ use frame_support::traits::OnRuntimeUpgrade;
 
 use crate::{Config, PalletStorageVersion, pallet::StorageVersion};
 
-pub mod v5 {
+pub mod v4 {
     use super::*;
     use crate::*;
 
-    #[derive(Encode, Decode, Clone, PartialEq, Eq, Debug, TypeInfo)]
-    pub enum LegalOfficerDataV4<AccountId, Region> {
-        Host(HostDataV4<Region>),
-        Guest(AccountId),
-    }
-
-    pub type LegalOfficerDataV4Of<T> = LegalOfficerDataV4<
-        <T as frame_system::Config>::AccountId,
-        <T as pallet::Config>::Region,
-    >;
-
-    #[derive(Encode, Decode, Clone, PartialEq, Eq, Debug, TypeInfo)]
-    pub struct HostDataV4<Region> {
-		pub node_id: Option<PeerId>,
-		pub base_url: Option<Vec<u8>>,
-		pub region: Region,
-    }
-
-    pub struct BoundedBaseUrl<T>(sp_std::marker::PhantomData<T>);
-    impl<T: Config> OnRuntimeUpgrade for BoundedBaseUrl<T> {
+    pub struct Dummy<T>(sp_std::marker::PhantomData<T>);
+    impl<T: Config> OnRuntimeUpgrade for Dummy<T> {
 
         fn on_runtime_upgrade() -> Weight {
             super::do_storage_upgrade::<T, _>(
                 StorageVersion::V4Region,
                 StorageVersion::V4Region,
-                "BoundedBaseUrl",
+                "Dummy",
                 || {
-                    LegalOfficerSet::<T>::translate_values(|legal_officer_data: LegalOfficerDataV4Of<T>| {
-                        match legal_officer_data {
-                            LegalOfficerDataV4::Guest(guest_data) => Some(LegalOfficerData::Guest(guest_data)),
-                            LegalOfficerDataV4::Host(host_data) => Some(LegalOfficerData::Host(HostData {
-                                node_id: host_data.node_id.clone(),
-                                base_url: match host_data.base_url {
-									None => None,
-									Some(url) => Some(BoundedVec::try_from(url).expect("Failed to migrate base_url")),
-								},
-                                region: host_data.region.clone(),
-                            })),
-                        }
-                    })
+                    LegalOfficerSet::<T>::translate_values(|legal_officer_data: LegalOfficerDataOf<T>| { Some(legal_officer_data) } );
                 }
             )
         }

--- a/pallet-lo-authority-list/src/mock.rs
+++ b/pallet-lo-authority-list/src/mock.rs
@@ -1,8 +1,9 @@
-use crate::{self as pallet_lo_authority_list, HostData, HostDataOf};
-use codec::{Encode, Decode};
+use crate::{self as pallet_lo_authority_list, HostDataParam, HostDataParamOf};
+use codec::{Encode, Decode, MaxEncodedLen};
 use frame_support::parameter_types;
 use frame_system::{self as system, EnsureRoot};
 use scale_info::TypeInfo;
+use sp_core::ConstU32;
 use sp_core::hash::H256;
 use sp_runtime::{
     traits::{BlakeTwo256, IdentityLookup}, testing::Header, generic,
@@ -50,7 +51,7 @@ impl system::Config for Test {
     type MaxConsumers = frame_support::traits::ConstU32<16>;
 }
 
-#[derive(Encode, Decode, Clone, PartialEq, Eq, Debug, TypeInfo, Copy)]
+#[derive(Encode, Decode, Clone, PartialEq, Eq, Debug, TypeInfo, Copy, MaxEncodedLen)]
 pub enum Region {
     Europe,
     Other,
@@ -75,15 +76,20 @@ impl Default for Region {
     }
 }
 
-impl Default for HostDataOf<Test> {
+impl Default for HostDataParamOf<Test> {
 
     fn default() -> Self {
-        return HostData {
+        return HostDataParam {
             node_id: None,
             base_url: None,
             region: Region::Europe,
         }
     }
+}
+
+parameter_types! {
+	#[derive(Debug, Eq, Clone, PartialEq, TypeInfo)]
+	pub const MaxBaseUrlLen: u32 = 30;
 }
 
 impl pallet_lo_authority_list::Config for Test {
@@ -93,6 +99,9 @@ impl pallet_lo_authority_list::Config for Test {
     type Region = Region;
     type RuntimeEvent = RuntimeEvent;
 	type WeightInfo = SubstrateWeight<Test>;
+	type MaxBaseUrlLen = MaxBaseUrlLen;
+	type MaxNodes = ConstU32<3>;
+	type MaxPeerIdLength = ConstU32<48>;
 }
 
 // Build genesis storage according to the mock runtime.

--- a/pallet-lo-authority-list/src/mock.rs
+++ b/pallet-lo-authority-list/src/mock.rs
@@ -3,7 +3,6 @@ use codec::{Encode, Decode, MaxEncodedLen};
 use frame_support::parameter_types;
 use frame_system::{self as system, EnsureRoot};
 use scale_info::TypeInfo;
-use sp_core::ConstU32;
 use sp_core::hash::H256;
 use sp_runtime::{
     traits::{BlakeTwo256, IdentityLookup}, testing::Header, generic,
@@ -90,6 +89,9 @@ impl Default for HostDataParamOf<Test> {
 parameter_types! {
 	#[derive(Debug, Eq, Clone, PartialEq, TypeInfo)]
 	pub const MaxBaseUrlLen: u32 = 30;
+	pub const MaxNodes: u32 = 3;
+	#[derive(Debug, Eq, Clone, PartialEq, TypeInfo, PartialOrd, Ord)]
+	pub const MaxPeerIdLength: u32 = 48;
 }
 
 impl pallet_lo_authority_list::Config for Test {
@@ -100,8 +102,8 @@ impl pallet_lo_authority_list::Config for Test {
     type RuntimeEvent = RuntimeEvent;
 	type WeightInfo = SubstrateWeight<Test>;
 	type MaxBaseUrlLen = MaxBaseUrlLen;
-	type MaxNodes = ConstU32<3>;
-	type MaxPeerIdLength = ConstU32<48>;
+	type MaxNodes = MaxNodes;
+	type MaxPeerIdLength = MaxPeerIdLength;
 }
 
 // Build genesis storage according to the mock runtime.

--- a/pallet-lo-authority-list/src/tests.rs
+++ b/pallet-lo-authority-list/src/tests.rs
@@ -1,8 +1,10 @@
-use crate::{mock::*, LegalOfficerData, Error, LegalOfficerDataOf, HostDataOf, LegalOfficerDataParam, HostDataParam, LegalOfficerDataParamOf};
+use crate::{mock::*, LegalOfficerData, Error, LegalOfficerDataOf, HostDataOf, LegalOfficerDataParam, HostDataParam, LegalOfficerDataParamOf, BoundedPeerId};
 use frame_support::{assert_err, assert_ok};
 use logion_shared::IsLegalOfficer;
 use sp_core::OpaquePeerId;
 use sp_runtime::traits::BadOrigin;
+use frame_support::traits::Len;
+use sp_runtime::BoundedVec;
 
 const LEGAL_OFFICER_ID: u64 = 1;
 const ANOTHER_ID: u64 = 2;
@@ -120,9 +122,12 @@ fn it_lets_host_update() {
         })));
         let data: HostDataOf<Test> = LoAuthorityList::legal_officer_set(LEGAL_OFFICER_ID).unwrap().try_into().unwrap();
         assert_eq!(data.base_url.unwrap(), base_url);
-        assert_eq!(data.node_id.unwrap(), node_id);
+		let bounded_node_id = BoundedPeerId::new(BoundedVec::try_from(node_id.0)
+			.expect("Failed to create expected node_id")
+		);
+        assert_eq!(data.node_id.unwrap(), bounded_node_id);
         assert_eq!(LoAuthorityList::legal_officer_nodes().len(), 1);
-        assert!(LoAuthorityList::legal_officer_nodes().contains(&node_id));
+        assert!(LoAuthorityList::legal_officer_nodes().contains(&bounded_node_id));
     });
 }
 
@@ -139,9 +144,12 @@ fn it_lets_superuser_update() {
         })));
         let data: HostDataOf<Test> = LoAuthorityList::legal_officer_set(LEGAL_OFFICER_ID).unwrap().try_into().unwrap();
         assert_eq!(data.base_url.unwrap(), base_url);
-        assert_eq!(data.node_id.unwrap(), node_id);
+		let bounded_node_id = BoundedPeerId::new(BoundedVec::try_from(node_id.0)
+			.expect("Failed to create expected node_id")
+		);
+        assert_eq!(data.node_id.unwrap(), bounded_node_id);
         assert_eq!(LoAuthorityList::legal_officer_nodes().len(), 1);
-        assert!(LoAuthorityList::legal_officer_nodes().contains(&node_id));
+        assert!(LoAuthorityList::legal_officer_nodes().contains(&bounded_node_id));
     });
 }
 
@@ -184,8 +192,14 @@ fn it_fails_update_if_peer_id_already_in_use() {
             region: Region::Europe,
         })));
         assert_eq!(LoAuthorityList::legal_officer_nodes().len(), 2);
-        assert!(LoAuthorityList::legal_officer_nodes().contains(&node_id1));
-        assert!(LoAuthorityList::legal_officer_nodes().contains(&node_id2));
+		let bounded_node_id1 = BoundedPeerId::new(BoundedVec::try_from(node_id1.clone().0)
+			.expect("Failed to create expected node_id")
+		);
+        assert!(LoAuthorityList::legal_officer_nodes().contains(&bounded_node_id1));
+		let bounded_node_id2 = BoundedPeerId::new(BoundedVec::try_from(node_id2.0)
+			.expect("Failed to create expected node_id")
+		);
+        assert!(LoAuthorityList::legal_officer_nodes().contains(&bounded_node_id2));
 
         assert_err!(LoAuthorityList::update_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID2, LegalOfficerDataParam::Host(HostDataParam {
             base_url: Option::Some(base_url2.clone()),
@@ -228,7 +242,10 @@ fn it_updates_nodes_on_update() {
         })));
 
         assert_eq!(LoAuthorityList::legal_officer_nodes().len(), 1);
-        assert!(LoAuthorityList::legal_officer_nodes().contains(&node_id2));
+		let bounded_node_id2 = BoundedPeerId::new(BoundedVec::try_from(node_id2.0)
+			.expect("Failed to create expected node_id")
+		);
+        assert!(LoAuthorityList::legal_officer_nodes().contains(&bounded_node_id2));
     });
 }
 

--- a/pallet-lo-authority-list/src/tests.rs
+++ b/pallet-lo-authority-list/src/tests.rs
@@ -1,4 +1,4 @@
-use crate::{mock::*, LegalOfficerData, Error, HostData, LegalOfficerDataOf, HostDataOf};
+use crate::{mock::*, LegalOfficerData, Error, LegalOfficerDataOf, HostDataOf, LegalOfficerDataParam, HostDataParam, LegalOfficerDataParamOf};
 use frame_support::{assert_err, assert_ok};
 use logion_shared::IsLegalOfficer;
 use sp_core::OpaquePeerId;
@@ -8,10 +8,11 @@ const LEGAL_OFFICER_ID: u64 = 1;
 const ANOTHER_ID: u64 = 2;
 const LEGAL_OFFICER_ID2: u64 = 3;
 const LEGAL_OFFICER_ID3: u64 = 4;
+const LEGAL_OFFICER_ID4: u64 = 5;
 
-impl Default for LegalOfficerDataOf<Test> {
+impl Default for LegalOfficerDataParamOf<Test> {
     fn default() -> Self {
-        LegalOfficerData::Host(Default::default())
+        LegalOfficerDataParam::Host(Default::default())
     }
 }
 
@@ -112,7 +113,7 @@ fn it_lets_host_update() {
         assert_ok!(LoAuthorityList::add_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID, Default::default()));
         let base_url = "https://node.logion.network".as_bytes().to_vec();
         let node_id = OpaquePeerId(bs58::decode("12D3KooWBmAwcd4PJNJvfV89HwE48nwkRmAgo8Vy3uQEyNNHBox2").into_vec().unwrap());
-        assert_ok!(LoAuthorityList::update_legal_officer(RuntimeOrigin::signed(LEGAL_OFFICER_ID), LEGAL_OFFICER_ID, LegalOfficerData::Host(HostData {
+        assert_ok!(LoAuthorityList::update_legal_officer(RuntimeOrigin::signed(LEGAL_OFFICER_ID), LEGAL_OFFICER_ID, LegalOfficerDataParam::Host(HostDataParam {
             node_id: Option::Some(node_id.clone()),
             base_url: Option::Some(base_url.clone()),
             region: Region::Europe,
@@ -131,7 +132,7 @@ fn it_lets_superuser_update() {
         assert_ok!(LoAuthorityList::add_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID, Default::default()));
         let base_url = "https://node.logion.network".as_bytes().to_vec();
         let node_id = OpaquePeerId(bs58::decode("12D3KooWBmAwcd4PJNJvfV89HwE48nwkRmAgo8Vy3uQEyNNHBox2").into_vec().unwrap());
-        assert_ok!(LoAuthorityList::update_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID, LegalOfficerData::Host(HostData {
+        assert_ok!(LoAuthorityList::update_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID, LegalOfficerDataParam::Host(HostDataParam {
             node_id: Option::Some(node_id.clone()),
             base_url: Option::Some(base_url.clone()),
             region: Region::Europe,
@@ -149,14 +150,14 @@ fn it_fails_add_if_peer_id_already_in_use() {
     new_test_ext().execute_with(|| {
         let base_url1 = "https://node1.logion.network".as_bytes().to_vec();
         let node_id1 = OpaquePeerId(bs58::decode("12D3KooWBmAwcd4PJNJvfV89HwE48nwkRmAgo8Vy3uQEyNNHBox2").into_vec().unwrap());
-        assert_ok!(LoAuthorityList::add_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID, LegalOfficerData::Host(HostData {
+        assert_ok!(LoAuthorityList::add_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID, LegalOfficerDataParam::Host(HostDataParam {
             node_id: Option::Some(node_id1.clone()),
             base_url: Option::Some(base_url1.clone()),
             region: Region::Europe,
         })));
 
         let base_url2 = "https://node2.logion.network".as_bytes().to_vec();
-        assert_err!(LoAuthorityList::add_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID2, LegalOfficerData::Host(HostData {
+        assert_err!(LoAuthorityList::add_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID2, LegalOfficerDataParam::Host(HostDataParam {
             base_url: Option::Some(base_url2.clone()),
             node_id: Option::Some(node_id1.clone()),
             region: Region::Europe,
@@ -169,7 +170,7 @@ fn it_fails_update_if_peer_id_already_in_use() {
     new_test_ext().execute_with(|| {
         let base_url1 = "https://node1.logion.network".as_bytes().to_vec();
         let node_id1 = OpaquePeerId(bs58::decode("12D3KooWBmAwcd4PJNJvfV89HwE48nwkRmAgo8Vy3uQEyNNHBox2").into_vec().unwrap());
-        assert_ok!(LoAuthorityList::add_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID, LegalOfficerData::Host(HostData {
+        assert_ok!(LoAuthorityList::add_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID, LegalOfficerDataParam::Host(HostDataParam {
             node_id: Option::Some(node_id1.clone()),
             base_url: Option::Some(base_url1.clone()),
             region: Region::Europe,
@@ -177,7 +178,7 @@ fn it_fails_update_if_peer_id_already_in_use() {
 
         let base_url2 = "https://node2.logion.network".as_bytes().to_vec();
         let node_id2 = OpaquePeerId(bs58::decode("12D3KooWQYV9dGMFoRzNStwpXztXaBUjtPqi6aU76ZgUriHhKust").into_vec().unwrap());
-        assert_ok!(LoAuthorityList::add_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID2, LegalOfficerData::Host(HostData {
+        assert_ok!(LoAuthorityList::add_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID2, LegalOfficerDataParam::Host(HostDataParam {
             base_url: Option::Some(base_url2.clone()),
             node_id: Option::Some(node_id2.clone()),
             region: Region::Europe,
@@ -186,7 +187,7 @@ fn it_fails_update_if_peer_id_already_in_use() {
         assert!(LoAuthorityList::legal_officer_nodes().contains(&node_id1));
         assert!(LoAuthorityList::legal_officer_nodes().contains(&node_id2));
 
-        assert_err!(LoAuthorityList::update_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID2, LegalOfficerData::Host(HostData {
+        assert_err!(LoAuthorityList::update_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID2, LegalOfficerDataParam::Host(HostDataParam {
             base_url: Option::Some(base_url2.clone()),
             node_id: Option::Some(node_id1.clone()),
             region: Region::Europe,
@@ -199,7 +200,7 @@ fn it_updates_nodes_on_remove() {
     new_test_ext().execute_with(|| {
         let base_url = "https://node.logion.network".as_bytes().to_vec();
         let node_id = OpaquePeerId(bs58::decode("12D3KooWBmAwcd4PJNJvfV89HwE48nwkRmAgo8Vy3uQEyNNHBox2").into_vec().unwrap());
-        assert_ok!(LoAuthorityList::add_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID, LegalOfficerData::Host(HostData {
+        assert_ok!(LoAuthorityList::add_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID, LegalOfficerDataParam::Host(HostDataParam {
             node_id: Option::Some(node_id.clone()),
             base_url: Option::Some(base_url.clone()),
             region: Region::Europe,
@@ -214,13 +215,13 @@ fn it_updates_nodes_on_update() {
     new_test_ext().execute_with(|| {
         let base_url = "https://node.logion.network".as_bytes().to_vec();
         let node_id1 = OpaquePeerId(bs58::decode("12D3KooWBmAwcd4PJNJvfV89HwE48nwkRmAgo8Vy3uQEyNNHBox2").into_vec().unwrap());
-        assert_ok!(LoAuthorityList::add_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID, LegalOfficerData::Host(HostData {
+        assert_ok!(LoAuthorityList::add_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID, LegalOfficerDataParam::Host(HostDataParam {
             node_id: Option::Some(node_id1.clone()),
             base_url: Option::Some(base_url.clone()),
             region: Region::Europe,
         })));
         let node_id2 = OpaquePeerId(bs58::decode("12D3KooWQYV9dGMFoRzNStwpXztXaBUjtPqi6aU76ZgUriHhKust").into_vec().unwrap());
-        assert_ok!(LoAuthorityList::update_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID, LegalOfficerData::Host(HostData {
+        assert_ok!(LoAuthorityList::update_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID, LegalOfficerDataParam::Host(HostDataParam {
             node_id: Option::Some(node_id2.clone()),
             base_url: Option::Some(base_url.clone()),
             region: Region::Europe,
@@ -241,13 +242,13 @@ fn it_adds_guest() {
 }
 
 fn setup_host_and_guest() {
-    let host_data = LegalOfficerData::Host(HostData {
+    let host_data = LegalOfficerDataParam::Host(HostDataParam {
         node_id: Option::Some(OpaquePeerId(bs58::decode("12D3KooWBmAwcd4PJNJvfV89HwE48nwkRmAgo8Vy3uQEyNNHBox2").into_vec().unwrap())),
         base_url: Option::Some("https://node.logion.network".as_bytes().to_vec()),
         region: Region::Europe,
     });
     assert_ok!(LoAuthorityList::add_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID, host_data));
-    assert_ok!(LoAuthorityList::add_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID2, LegalOfficerData::Guest(LEGAL_OFFICER_ID)));
+    assert_ok!(LoAuthorityList::add_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID2, LegalOfficerDataParam::Guest(LEGAL_OFFICER_ID)));
 }
 
 #[test]
@@ -264,7 +265,7 @@ fn it_removes_guest() {
 fn it_turns_guest_into_host() {
     new_test_ext().execute_with(|| {
         setup_host_and_guest();
-        let host_data2 = LegalOfficerData::Host(HostData {
+        let host_data2 = LegalOfficerDataParam::Host(HostDataParam {
             node_id: Option::Some(OpaquePeerId(bs58::decode("12D3KooWQYV9dGMFoRzNStwpXztXaBUjtPqi6aU76ZgUriHhKust").into_vec().unwrap())),
             base_url: Option::Some("https://node2.logion.network".as_bytes().to_vec()),
             region: Region::Europe,
@@ -279,27 +280,27 @@ fn it_turns_guest_into_host() {
 fn it_turns_host_into_guest() {
     new_test_ext().execute_with(|| {
         setup_hosts();
-        let host_data = LegalOfficerData::Host(HostData {
+        let host_data = LegalOfficerDataParam::Host(HostDataParam {
             node_id: Option::Some(OpaquePeerId(bs58::decode("12D3KooWJvyP3VJYymTqG7eH4PM5rN4T2agk5cdNCfNymAqwqcvZ").into_vec().unwrap())),
             base_url: Option::Some("https://node3.logion.network".as_bytes().to_vec()),
             region: Region::Other,
         });
         assert_ok!(LoAuthorityList::add_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID3, host_data));
         assert_eq!(LoAuthorityList::legal_officer_nodes().len(), 3);
-        assert_ok!(LoAuthorityList::update_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID2, LegalOfficerData::Guest(LEGAL_OFFICER_ID3)));
+        assert_ok!(LoAuthorityList::update_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID2, LegalOfficerDataParam::Guest(LEGAL_OFFICER_ID3)));
         assert!(LoAuthorityList::legal_officer_set(LEGAL_OFFICER_ID2).is_some());
         assert_eq!(LoAuthorityList::legal_officer_nodes().len(), 2);
     });
 }
 
 fn setup_hosts() {
-    let host_data = LegalOfficerData::Host(HostData {
+    let host_data = LegalOfficerDataParam::Host(HostDataParam {
         node_id: Option::Some(OpaquePeerId(bs58::decode("12D3KooWBmAwcd4PJNJvfV89HwE48nwkRmAgo8Vy3uQEyNNHBox2").into_vec().unwrap())),
         base_url: Option::Some("https://node1.logion.network".as_bytes().to_vec()),
         region: Region::Europe,
     });
     assert_ok!(LoAuthorityList::add_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID, host_data));
-    let host_data2 = LegalOfficerData::Host(HostData {
+    let host_data2 = LegalOfficerDataParam::Host(HostDataParam {
         node_id: Option::Some(OpaquePeerId(bs58::decode("12D3KooWQYV9dGMFoRzNStwpXztXaBUjtPqi6aU76ZgUriHhKust").into_vec().unwrap())),
         base_url: Option::Some("https://node2.logion.network".as_bytes().to_vec()),
         region: Region::Other,
@@ -311,13 +312,13 @@ fn setup_hosts() {
 fn it_fails_turning_host_with_guest_into_guest() {
     new_test_ext().execute_with(|| {
         setup_host_and_guest();
-        let host_data3 = LegalOfficerData::Host(HostData {
+        let host_data3 = LegalOfficerDataParam::Host(HostDataParam {
             node_id: Option::Some(OpaquePeerId(bs58::decode("12D3KooWJvyP3VJYymTqG7eH4PM5rN4T2agk5cdNCfNymAqwqcvZ").into_vec().unwrap())),
             base_url: Option::Some("https://node3.logion.network".as_bytes().to_vec()),
             region: Region::Europe,
         });
         assert_ok!(LoAuthorityList::add_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID3, host_data3));
-        assert_err!(LoAuthorityList::update_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID, LegalOfficerData::Guest(LEGAL_OFFICER_ID3)),
+        assert_err!(LoAuthorityList::update_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID, LegalOfficerDataParam::Guest(LEGAL_OFFICER_ID3)),
             Error::<Test>::HostHasGuest);
     });
 }
@@ -334,7 +335,7 @@ fn it_fails_removing_host_with_guests() {
 fn it_fails_adding_guest_with_guest() {
     new_test_ext().execute_with(|| {
         setup_host_and_guest();
-        assert_err!(LoAuthorityList::add_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID3, LegalOfficerData::Guest(LEGAL_OFFICER_ID2)),
+        assert_err!(LoAuthorityList::add_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID3, LegalOfficerDataParam::Guest(LEGAL_OFFICER_ID2)),
             Error::<Test>::GuestOfGuest);
     });
 }
@@ -342,13 +343,13 @@ fn it_fails_adding_guest_with_guest() {
 #[test]
 fn it_fails_adding_guest_with_unknown_host() {
     new_test_ext().execute_with(|| {
-        let host_data = LegalOfficerData::Host(HostData {
+        let host_data = LegalOfficerDataParam::Host(HostDataParam {
             node_id: Option::Some(OpaquePeerId(bs58::decode("12D3KooWBmAwcd4PJNJvfV89HwE48nwkRmAgo8Vy3uQEyNNHBox2").into_vec().unwrap())),
             base_url: Option::Some("https://node.logion.network".as_bytes().to_vec()),
             region: Region::Europe,
         });
         assert_ok!(LoAuthorityList::add_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID, host_data));
-        assert_err!(LoAuthorityList::add_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID2, LegalOfficerData::Guest(LEGAL_OFFICER_ID3)),
+        assert_err!(LoAuthorityList::add_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID2, LegalOfficerDataParam::Guest(LEGAL_OFFICER_ID3)),
             Error::<Test>::HostNotFound);
     });
 }
@@ -357,7 +358,7 @@ fn it_fails_adding_guest_with_unknown_host() {
 fn it_fails_if_guest_updates() {
     new_test_ext().execute_with(|| {
         setup_host_and_guest();
-        assert_err!(LoAuthorityList::update_legal_officer(RuntimeOrigin::signed(LEGAL_OFFICER_ID2), LEGAL_OFFICER_ID2, LegalOfficerData::Guest(LEGAL_OFFICER_ID)),
+        assert_err!(LoAuthorityList::update_legal_officer(RuntimeOrigin::signed(LEGAL_OFFICER_ID2), LEGAL_OFFICER_ID2, LegalOfficerDataParam::Guest(LEGAL_OFFICER_ID)),
             Error::<Test>::GuestCannotUpdate);
     });
 }
@@ -366,7 +367,7 @@ fn it_fails_if_guest_updates() {
 fn it_fails_if_host_converts_to_guest() {
     new_test_ext().execute_with(|| {
         setup_hosts();
-        assert_err!(LoAuthorityList::update_legal_officer(RuntimeOrigin::signed(LEGAL_OFFICER_ID), LEGAL_OFFICER_ID, LegalOfficerData::Guest(LEGAL_OFFICER_ID2)),
+        assert_err!(LoAuthorityList::update_legal_officer(RuntimeOrigin::signed(LEGAL_OFFICER_ID), LEGAL_OFFICER_ID, LegalOfficerDataParam::Guest(LEGAL_OFFICER_ID2)),
             Error::<Test>::HostCannotConvert);
     });
 }
@@ -375,7 +376,7 @@ fn it_fails_if_host_converts_to_guest() {
 fn it_fails_changing_host_host_region() {
     new_test_ext().execute_with(|| {
         setup_hosts();
-        assert_err!(LoAuthorityList::update_legal_officer(RuntimeOrigin::signed(LEGAL_OFFICER_ID), LEGAL_OFFICER_ID, LegalOfficerData::Host(HostData {
+        assert_err!(LoAuthorityList::update_legal_officer(RuntimeOrigin::signed(LEGAL_OFFICER_ID), LEGAL_OFFICER_ID, LegalOfficerDataParam::Host(HostDataParam {
             node_id: Option::Some(OpaquePeerId(bs58::decode("12D3KooWBmAwcd4PJNJvfV89HwE48nwkRmAgo8Vy3uQEyNNHBox2").into_vec().unwrap())),
             base_url: Option::Some("https://node1.logion.network".as_bytes().to_vec()),
             region: Region::Other,
@@ -387,13 +388,13 @@ fn it_fails_changing_host_host_region() {
 fn it_fails_changing_guest_host_region() {
     new_test_ext().execute_with(|| {
         setup_host_and_guest();
-        let host_data = LegalOfficerData::Host(HostData {
+        let host_data = LegalOfficerDataParam::Host(HostDataParam {
             node_id: Option::Some(OpaquePeerId(bs58::decode("12D3KooWQYV9dGMFoRzNStwpXztXaBUjtPqi6aU76ZgUriHhKust").into_vec().unwrap())),
             base_url: Option::Some("https://node2.logion.network".as_bytes().to_vec()),
             region: Region::Other,
         });
         assert_ok!(LoAuthorityList::add_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID3, host_data));
-        assert_err!(LoAuthorityList::update_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID2, LegalOfficerData::Guest(LEGAL_OFFICER_ID3)), Error::<Test>::CannotChangeRegion);
+        assert_err!(LoAuthorityList::update_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID2, LegalOfficerDataParam::Guest(LEGAL_OFFICER_ID3)), Error::<Test>::CannotChangeRegion);
     });
 }
 
@@ -401,7 +402,7 @@ fn it_fails_changing_guest_host_region() {
 fn it_fails_changing_host_guest_region() {
     new_test_ext().execute_with(|| {
         setup_hosts();
-        assert_err!(LoAuthorityList::update_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID2, LegalOfficerData::Guest(LEGAL_OFFICER_ID)), Error::<Test>::CannotChangeRegion);
+        assert_err!(LoAuthorityList::update_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID2, LegalOfficerDataParam::Guest(LEGAL_OFFICER_ID)), Error::<Test>::CannotChangeRegion);
     });
 }
 
@@ -409,7 +410,79 @@ fn it_fails_changing_host_guest_region() {
 fn it_fails_changing_guest_guest_region() {
     new_test_ext().execute_with(|| {
         setup_hosts();
-        assert_ok!(LoAuthorityList::add_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID3, LegalOfficerData::Guest(LEGAL_OFFICER_ID)));
-        assert_err!(LoAuthorityList::update_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID3, LegalOfficerData::Guest(LEGAL_OFFICER_ID2)), Error::<Test>::CannotChangeRegion);
+        assert_ok!(LoAuthorityList::add_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID3, LegalOfficerDataParam::Guest(LEGAL_OFFICER_ID)));
+        assert_err!(LoAuthorityList::update_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID3, LegalOfficerDataParam::Guest(LEGAL_OFFICER_ID2)), Error::<Test>::CannotChangeRegion);
     });
+}
+
+#[test]
+fn it_fails_to_add_too_many_nodes() {
+	new_test_ext().execute_with(|| {
+		setup_hosts();
+		let host_data3 = LegalOfficerDataParam::Host(HostDataParam {
+			node_id: Option::Some(OpaquePeerId(bs58::decode("12D3KooWJvyP3VJYymTqG7eH4PM5rN4T2agk5cdNCfNymAqwqcvZ").into_vec().unwrap())),
+			base_url: Option::Some("https://node3.logion.network".as_bytes().to_vec()),
+			region: Region::Other,
+		});
+		assert_ok!(LoAuthorityList::add_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID3, host_data3));
+		let host_data4 = LegalOfficerDataParam::Host(HostDataParam {
+			node_id: Option::Some(OpaquePeerId(bs58::decode("12D3KooWFps8hKkh2L6YBaT1icfJARThmzofyJ5dpDPxBPCnxgjQ").into_vec().unwrap())),
+			base_url: Option::Some("https://node4.logion.network".as_bytes().to_vec()),
+			region: Region::Other,
+		});
+		assert_err!(LoAuthorityList::add_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID4, host_data4), Error::<Test>::TooManyNodes);
+	});
+}
+
+#[test]
+fn it_fails_to_add_when_base_url_too_long() {
+	new_test_ext().execute_with(|| {
+		let host_data = LegalOfficerDataParam::Host(HostDataParam {
+			node_id: Option::Some(OpaquePeerId(bs58::decode("12D3KooWFps8hKkh2L6YBaT1icfJARThmzofyJ5dpDPxBPCnxgjQ").into_vec().unwrap())),
+			base_url: Option::Some("https://node1.logion.network/way-too-long-to-fit-in-storage".as_bytes().to_vec()),
+			region: Region::Europe,
+		});
+		assert_err!(LoAuthorityList::add_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID, host_data), Error::<Test>::BaseUrlTooLong);
+	});
+}
+
+#[test]
+fn it_fails_to_update_when_base_url_too_long() {
+	new_test_ext().execute_with(|| {
+		setup_hosts();
+		let host_data = LegalOfficerDataParam::Host(HostDataParam {
+			node_id: Option::Some(OpaquePeerId(bs58::decode("12D3KooWBmAwcd4PJNJvfV89HwE48nwkRmAgo8Vy3uQEyNNHBox2").into_vec().unwrap())),
+			base_url: Option::Some("https://node1.logion.network/way-too-long-to-fit-in-storage".as_bytes().to_vec()),
+			region: Region::Europe,
+		});
+		assert_err!(LoAuthorityList::update_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID, host_data), Error::<Test>::BaseUrlTooLong);
+	});
+}
+
+
+#[test]
+fn it_fails_to_add_when_node_id_too_long() {
+	new_test_ext().execute_with(|| {
+		let big_node_id: [u8; 500] = [81; 500];
+		let host_data = LegalOfficerDataParam::Host(HostDataParam {
+			node_id: Option::Some(OpaquePeerId(big_node_id.to_vec())),
+			base_url: Option::Some("https://node1.logion.network".as_bytes().to_vec()),
+			region: Region::Europe,
+		});
+		assert_err!(LoAuthorityList::add_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID, host_data), Error::<Test>::PeerIdTooLong);
+	});
+}
+
+#[test]
+fn it_fails_to_update_when_node_id_too_long() {
+	new_test_ext().execute_with(|| {
+		let big_node_id: [u8; 500] = [81; 500];
+		setup_hosts();
+		let host_data = LegalOfficerDataParam::Host(HostDataParam {
+			node_id: Option::Some(OpaquePeerId(big_node_id.to_vec())),
+			base_url: Option::Some("https://node1.logion.network".as_bytes().to_vec()),
+			region: Region::Europe,
+		});
+		assert_err!(LoAuthorityList::update_legal_officer(RuntimeOrigin::root(), LEGAL_OFFICER_ID, host_data), Error::<Test>::PeerIdTooLong);
+	});
 }


### PR DESCRIPTION
* `BTreeSet` is replaced by `BoundedBTreeSet`.
* `Vec` is replaced by `BoundedVec`.
* `OpaquePeerId` is replace by locally-defined `BoundedPeerId`.
* Annotation `#[pallet::without_storage_info]` is removed.
* A dummy migration is provided - the previous one was broken - but must not be called in node.

logion-network/logion-internal#488